### PR TITLE
Add Redshift Engine

### DIFF
--- a/etc/templates/deploy/redshift.tmpl
+++ b/etc/templates/deploy/redshift.tmpl
@@ -1,0 +1,13 @@
+-- Deploy [% project %]:[% change %] to [% engine %]
+[% FOREACH item IN requires -%]
+-- requires: [% item %]
+[% END -%]
+[% FOREACH item IN conflicts -%]
+-- conflicts: [% item %]
+[% END -%]
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/etc/templates/revert/redshift.tmpl
+++ b/etc/templates/revert/redshift.tmpl
@@ -1,0 +1,7 @@
+-- Revert [% project %]:[% change %] from [% engine %]
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/etc/templates/verify/redshift.tmpl
+++ b/etc/templates/verify/redshift.tmpl
@@ -1,0 +1,7 @@
+-- Verify [% project %]:[% change %] on [% engine %]
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/lib/App/Sqitch/Command.pm
+++ b/lib/App/Sqitch/Command.pm
@@ -20,6 +20,7 @@ use constant ENGINES => qw(
     oracle
     firebird
     vertica
+    redshift
 );
 
 has sqitch => (

--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -106,19 +106,7 @@ has dbh => (
                 goto &hurl;
             },
             Callbacks         => {
-                connected => sub {
-                    my $dbh = shift;
-                    $dbh->do('SET client_min_messages = WARNING');
-                    try {
-                        $dbh->do(
-                            'SET search_path = ?',
-                            undef, $self->registry
-                        );
-                        # http://www.nntp.perl.org/group/perl.dbi.dev/2013/11/msg7622.html
-                        $dbh->set_err(undef, undef) if $dbh->err;
-                    };
-                    return;
-                },
+                connected => sub { $self->_dbh_callback_connected(@_) },
             },
         });
     }
@@ -154,6 +142,20 @@ sub _listagg_format {
 sub _regex_op { '~' }
 
 sub _version_query { 'SELECT MAX(version)::TEXT FROM releases' }
+
+sub _dbh_callback_connected {
+    my ($self, $dbh) = @_;
+    $dbh->do('SET client_min_messages = WARNING');
+    try {
+        $dbh->do(
+            'SET search_path = ?',
+            undef, $self->registry
+        );
+        # http://www.nntp.perl.org/group/perl.dbi.dev/2013/11/msg7622.html
+        $dbh->set_err(undef, undef) if $dbh->err;
+    };
+    return;
+}
 
 sub initialized {
     my $self = shift;

--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -139,6 +139,8 @@ sub _listagg_format {
     q{ARRAY(SELECT * FROM UNNEST( array_agg(%s) ) a WHERE a IS NOT NULL)}
 }
 
+sub _registry_file{ file(__FILE__)->dir->file('pg.sql') }
+
 sub _regex_op { '~' }
 
 sub _version_query { 'SELECT MAX(version)::TEXT FROM releases' }
@@ -173,7 +175,7 @@ sub initialize {
         'Sqitch schema "{schema}" already exists',
         schema => $self->registry
     ) if $self->initialized;
-    $self->_run_registry_file( file(__FILE__)->dir->file('pg.sql') );
+    $self->_run_registry_file( $self->_registry_file );
     $self->_register_release;
 }
 

--- a/lib/App/Sqitch/Engine/redshift.pm
+++ b/lib/App/Sqitch/Engine/redshift.pm
@@ -1,0 +1,95 @@
+package App::Sqitch::Engine::redshift;
+
+use 5.010;
+use Moo;
+use utf8;
+use Path::Class;
+use Try::Tiny;
+use namespace::autoclean;
+
+extends 'App::Sqitch::Engine::pg';
+
+sub key    { 'redshift' }
+sub name   { 'Redshift' }
+sub driver { 'DBD::Pg 2.0' }
+sub default_client { 'psql' }
+
+sub _registry_file{ file(__FILE__)->dir->file('redshift.sql') }
+
+sub _ts_default { 'GETDATE()' }
+
+sub _ts2char_format {
+    q{'year:' || to_char(%1$s, 'YYYY') || ':month:' || to_char(%1$s, 'MM') || ':day:' || to_char(%1$s, 'DD') || ':hour:' || to_char(%1$s, 'HH24') || ':minute:' || to_char(%1$s, 'MI') || ':second:' || to_char(%1$s, 'SS') || ':time_zone:UTC'};
+}
+
+sub _dbh_callback_connected {
+    my ($self, $dbh) = @_;
+    try {
+        $dbh->do(
+            'SET search_path = ?',
+            undef, $self->registry
+        );
+        # http://www.nntp.perl.org/group/perl.dbi.dev/2013/11/msg7622.html
+        $dbh->set_err(undef, undef) if $dbh->err;
+    };
+    return;
+}
+
+sub _tag_column {
+    my ($self, $prefix) = @_;
+    $prefix ||= '';
+    $prefix &&= "${prefix}.";
+    return qq|${prefix}"tag"|;
+}
+
+sub _listagg_format {
+    q{listagg(%s, ' ')}
+}
+
+sub changes_requiring_change {
+    my ( $self, $change ) = @_;
+    my $tagcol = $self->_tag_column;
+    return @{ $self->dbh->selectall_arrayref(qq{
+        with asof_tag as (
+            SELECT tags.$tagcol
+            FROM dependencies d
+            JOIN changes c1 ON c1.change_id = d.change_id
+            JOIN changes c2 ON
+              c2.project = c1.project
+              AND c2.committed_at >= c1.committed_at
+            JOIN tags ON c2.change_id = tags.change_id
+            WHERE d.dependency_id = ?
+            ORDER BY c2.committed_at
+            LIMIT 1
+        )
+        SELECT c.change_id, c.project, c.change, asof_tag.$tagcol
+        FROM dependencies d
+        JOIN changes c ON c.change_id = d.change_id
+          LEFT JOIN asof_tag ON 1=1
+        WHERE d.dependency_id = ?
+    }, { Slice => {} }, $change->id, $change->id) };
+}
+
+sub log_revert_change {
+    my ($self, $change) = @_;
+    return App::Sqitch::Role::DBIEngine::log_revert_change($self, $change);
+}
+
+1;
+
+__END__
+
+=head1 Name
+
+App::Sqitch::Engine::redshift - Sqitch Redshift Engine
+
+=head1 Synopsis
+
+  my $redshift = App::Sqitch::Engine->load( engine => 'redshift' );
+
+=head1 Description
+
+App::Sqitch::Engine::redshift provides the AWS Redshift storage engine for
+Sqitch. It mostly uses the PostgreSQL engine underneath.
+
+=cut

--- a/lib/App/Sqitch/Engine/redshift.sql
+++ b/lib/App/Sqitch/Engine/redshift.sql
@@ -1,0 +1,139 @@
+BEGIN;
+
+CREATE SCHEMA :"registry";
+
+COMMENT ON SCHEMA :"registry" IS 'Sqitch database deployment metadata v1.0.';
+
+CREATE TABLE :"registry".releases (
+    version         REAL        PRIMARY KEY,
+    installed_at    TIMESTAMP   NOT NULL DEFAULT GETDATE(),
+    installer_name  TEXT        NOT NULL,
+    installer_email TEXT        NOT NULL
+);
+
+COMMENT ON TABLE  :"registry".releases                 IS 'Sqitch registry releases.';
+COMMENT ON COLUMN :"registry".releases.version         IS 'Version of the Sqitch registry.';
+COMMENT ON COLUMN :"registry".releases.installed_at    IS 'Date the registry release was installed.';
+COMMENT ON COLUMN :"registry".releases.installer_name  IS 'Name of the user who installed the registry release.';
+COMMENT ON COLUMN :"registry".releases.installer_email IS 'Email address of the user who installed the registry release.';
+
+CREATE TABLE :"registry".projects (
+    project         TEXT        PRIMARY KEY,
+    uri             TEXT            NULL UNIQUE,
+    created_at      TIMESTAMP   NOT NULL DEFAULT GETDATE(),
+    creator_name    TEXT        NOT NULL,
+    creator_email   TEXT        NOT NULL
+):tableopts;
+
+COMMENT ON TABLE  :"registry".projects                IS 'Sqitch projects deployed to this database.';
+COMMENT ON COLUMN :"registry".projects.project        IS 'Unique Name of a project.';
+COMMENT ON COLUMN :"registry".projects.uri            IS 'Optional project URI';
+COMMENT ON COLUMN :"registry".projects.created_at     IS 'Date the project was added to the database.';
+COMMENT ON COLUMN :"registry".projects.creator_name   IS 'Name of the user who added the project.';
+COMMENT ON COLUMN :"registry".projects.creator_email  IS 'Email address of the user who added the project.';
+
+CREATE TABLE :"registry".changes (
+    change_id       TEXT        PRIMARY KEY,
+    script_hash     TEXT            NULL,
+    change          TEXT        NOT NULL,
+    project         TEXT        NOT NULL REFERENCES :"registry".projects(project),
+    note            TEXT        NOT NULL DEFAULT '',
+    committed_at    TIMESTAMP   NOT NULL DEFAULT GETDATE(),
+    committer_name  TEXT        NOT NULL,
+    committer_email TEXT        NOT NULL,
+    planned_at      TIMESTAMP   NOT NULL,
+    planner_name    TEXT        NOT NULL,
+    planner_email   TEXT        NOT NULL,
+    UNIQUE(project, script_hash)
+):tableopts;
+
+COMMENT ON TABLE  :"registry".changes                 IS 'Tracks the changes currently deployed to the database.';
+COMMENT ON COLUMN :"registry".changes.change_id       IS 'Change primary key.';
+COMMENT ON COLUMN :"registry".changes.script_hash     IS 'Deploy script SHA-1 hash.';
+COMMENT ON COLUMN :"registry".changes.change          IS 'Name of a deployed change.';
+COMMENT ON COLUMN :"registry".changes.project         IS 'Name of the Sqitch project to which the change belongs.';
+COMMENT ON COLUMN :"registry".changes.note            IS 'Description of the change.';
+COMMENT ON COLUMN :"registry".changes.committed_at    IS 'Date the change was deployed.';
+COMMENT ON COLUMN :"registry".changes.committer_name  IS 'Name of the user who deployed the change.';
+COMMENT ON COLUMN :"registry".changes.committer_email IS 'Email address of the user who deployed the change.';
+COMMENT ON COLUMN :"registry".changes.planned_at      IS 'Date the change was added to the plan.';
+COMMENT ON COLUMN :"registry".changes.planner_name    IS 'Name of the user who planed the change.';
+COMMENT ON COLUMN :"registry".changes.planner_email   IS 'Email address of the user who planned the change.';
+
+CREATE TABLE :"registry".tags (
+    tag_id          TEXT        PRIMARY KEY,
+    "tag"           TEXT        NOT NULL,
+    project         TEXT        NOT NULL REFERENCES :"registry".projects(project),
+    change_id       TEXT        NOT NULL REFERENCES :"registry".changes(change_id),
+    note            TEXT        NOT NULL DEFAULT '',
+    committed_at    TIMESTAMP   NOT NULL DEFAULT GETDATE(),
+    committer_name  TEXT        NOT NULL,
+    committer_email TEXT        NOT NULL,
+    planned_at      TIMESTAMP   NOT NULL,
+    planner_name    TEXT        NOT NULL,
+    planner_email   TEXT        NOT NULL,
+    UNIQUE(project, "tag")
+):tableopts;
+
+COMMENT ON TABLE  :"registry".tags                 IS 'Tracks the tags currently applied to the database.';
+COMMENT ON COLUMN :"registry".tags.tag_id          IS 'Tag primary key.';
+COMMENT ON COLUMN :"registry".tags."tag"           IS 'Project-unique tag name.';
+COMMENT ON COLUMN :"registry".tags.project         IS 'Name of the Sqitch project to which the tag belongs.';
+COMMENT ON COLUMN :"registry".tags.change_id       IS 'ID of last change deployed before the tag was applied.';
+COMMENT ON COLUMN :"registry".tags.note            IS 'Description of the tag.';
+COMMENT ON COLUMN :"registry".tags.committed_at    IS 'Date the tag was applied to the database.';
+COMMENT ON COLUMN :"registry".tags.committer_name  IS 'Name of the user who applied the tag.';
+COMMENT ON COLUMN :"registry".tags.committer_email IS 'Email address of the user who applied the tag.';
+COMMENT ON COLUMN :"registry".tags.planned_at      IS 'Date the tag was added to the plan.';
+COMMENT ON COLUMN :"registry".tags.planner_name    IS 'Name of the user who planed the tag.';
+COMMENT ON COLUMN :"registry".tags.planner_email   IS 'Email address of the user who planned the tag.';
+
+CREATE TABLE :"registry".dependencies (
+    change_id       TEXT        NOT NULL REFERENCES :"registry".changes(change_id),
+    type            TEXT        NOT NULL,
+    dependency      TEXT        NOT NULL,
+    dependency_id   TEXT            NULL REFERENCES :"registry".changes(change_id),
+    PRIMARY KEY (change_id, dependency)
+):tableopts;
+
+COMMENT ON TABLE  :"registry".dependencies               IS 'Tracks the currently satisfied dependencies.';
+COMMENT ON COLUMN :"registry".dependencies.change_id     IS 'ID of the depending change.';
+COMMENT ON COLUMN :"registry".dependencies.type          IS 'Type of dependency.';
+COMMENT ON COLUMN :"registry".dependencies.dependency    IS 'Dependency name.';
+COMMENT ON COLUMN :"registry".dependencies.dependency_id IS 'Change ID the dependency resolves to.';
+
+CREATE TABLE :"registry".events (
+    event           TEXT        NOT NULL,
+    change_id       TEXT        NOT NULL,
+    change          TEXT        NOT NULL,
+    project         TEXT        NOT NULL REFERENCES :"registry".projects(project),
+    note            TEXT        NOT NULL DEFAULT '',
+    requires        TEXT        NOT NULL DEFAULT '{}',
+    conflicts       TEXT        NOT NULL DEFAULT '{}',
+    tags            TEXT        NOT NULL DEFAULT '{}',
+    committed_at    TIMESTAMP   NOT NULL DEFAULT GETDATE(),
+    committer_name  TEXT        NOT NULL,
+    committer_email TEXT        NOT NULL,
+    planned_at      TIMESTAMP   NOT NULL,
+    planner_name    TEXT        NOT NULL,
+    planner_email   TEXT        NOT NULL,
+    PRIMARY KEY (change_id, committed_at)
+):tableopts;
+
+COMMENT ON TABLE  :"registry".events                 IS 'Contains full history of all deployment events.';
+COMMENT ON COLUMN :"registry".events.event           IS 'Type of event.';
+COMMENT ON COLUMN :"registry".events.change_id       IS 'Change ID.';
+COMMENT ON COLUMN :"registry".events.change          IS 'Change name.';
+COMMENT ON COLUMN :"registry".events.project         IS 'Name of the Sqitch project to which the change belongs.';
+COMMENT ON COLUMN :"registry".events.note            IS 'Description of the change.';
+COMMENT ON COLUMN :"registry".events.requires        IS 'Array of the names of required changes.';
+COMMENT ON COLUMN :"registry".events.conflicts       IS 'Array of the names of conflicting changes.';
+COMMENT ON COLUMN :"registry".events.tags            IS 'Tags associated with the change.';
+COMMENT ON COLUMN :"registry".events.committed_at    IS 'Date the event was committed.';
+COMMENT ON COLUMN :"registry".events.committer_name  IS 'Name of the user who committed the event.';
+COMMENT ON COLUMN :"registry".events.committer_email IS 'Email address of the user who committed the event.';
+COMMENT ON COLUMN :"registry".events.planned_at      IS 'Date the event was added to the plan.';
+COMMENT ON COLUMN :"registry".events.planner_name    IS 'Name of the user who planed the change.';
+COMMENT ON COLUMN :"registry".events.planner_email   IS 'Email address of the user who plan planned the change.';
+
+COMMIT;

--- a/lib/App/Sqitch/Role/DBIEngine.pm
+++ b/lib/App/Sqitch/Role/DBIEngine.pm
@@ -92,13 +92,14 @@ sub registry_version {
 sub _cid {
     my ( $self, $ord, $offset, $project ) = @_;
     return try {
+        $offset //= 0;
         $self->dbh->selectcol_arrayref(qq{
             SELECT change_id
               FROM changes
              WHERE project = ?
              ORDER BY committed_at $ord
              LIMIT 1
-            OFFSET COALESCE(?, 0)
+            OFFSET ?
         }, undef, $project || $self->plan->project, $offset)->[0];
     } catch {
         return if $self->_no_table_error && !$self->initialized;

--- a/xt/release/pod-spelling.t
+++ b/xt/release/pod-spelling.t
@@ -101,3 +101,4 @@ TLS
 ident
 passwordless
 IDE
+AWS


### PR DESCRIPTION
Adds a new engine for AWS Redshift.  This code should be considered alpha code - I've tested deploy/verify/revert against my database, but there could very well be edge cases that are not working.

I'm also very open to suggestions on ways to improve the code.

NOTE: this depends on URI::db to support redshift, see: https://github.com/theory/uri-db/pull/12
