### PR TITLE
Cassandra support (very incomplete yet)

### DIFF
--- a/etc/templates/deploy/cassandra.tmpl
+++ b/etc/templates/deploy/cassandra.tmpl
@@ -1,0 +1,9 @@
+-- Deploy [% project %]:[% change %] to [% engine %]
+[% FOREACH item IN requires -%]
+-- requires: [% item %]
+[% END -%]
+[% FOREACH item IN conflicts -%]
+-- conflicts: [% item %]
+[% END -%]
+
+-- XXX Add DDLs here.

--- a/etc/templates/revert/cassandra.tmpl
+++ b/etc/templates/revert/cassandra.tmpl
@@ -1,0 +1,3 @@
+-- Revert [% project %]:[% change %] from [% engine %]
+
+-- XXX Add DDLs here.

--- a/etc/templates/verify/cassandra.tmpl
+++ b/etc/templates/verify/cassandra.tmpl
@@ -1,0 +1,3 @@
+-- Verify [% project %]:[% change %] on [% engine %]
+
+-- XXX Add verifications here.

--- a/lib/App/Sqitch/Command.pm
+++ b/lib/App/Sqitch/Command.pm
@@ -20,6 +20,7 @@ use constant ENGINES => qw(
     oracle
     firebird
     vertica
+    cassandra
 );
 
 has sqitch => (

--- a/lib/App/Sqitch/Engine/cassandra.cql
+++ b/lib/App/Sqitch/Engine/cassandra.cql
@@ -1,0 +1,157 @@
+CREATE KEYSPACE :"registry"
+WITH COMMENT = 'Sqitch database deployment metadata v1.0.',
+AND REPLICATION = {
+	'class': 'SimpleStrategy'
+	'replication_factor': 1
+},
+AND DURABLE_WRITES = true;
+
+CREATE TABLE :"registry".releases (
+	version         FLOAT PRIMARY KEY,
+	installed_at    TIMESTAMP.
+	installer_name  TEXT,
+	installer_email TEXT
+)
+WITH COMMENT = 'Sqitch registry releases.',
+AND CACHING = {
+	'keys': 'NONE',
+	'rows_per_partition': 'NONE'
+},
+AND GC_GRACE_SECONDS = 0,
+AND COMPRESSION = {
+	'class': 'LZ4Compressor'
+},
+AND CLUSTERING ORDER BY (version);
+
+CREATE TABLE :"registry".projects (
+	project       TEXT PRIMARY KEY,
+	uri           TEXT,
+	created_at    TIMESTAMP,
+	creator_name  TEXT,
+	creator_email TEXT
+)
+WITH COMMENT = 'Sqitch projects deployed to this database.',
+AND CACHING = {
+	'keys': 'NONE',
+	'rows_per_partition': 'NONE'
+},
+AND GC_GRACE_SECONDS = 0,
+AND COMPRESSION = {
+	'class': 'LZ4Compressor'
+},
+AND CLUSTERING ORDER BY (project);
+
+CREATE TABLE :"registry".changes (
+	change_id       TEXT PRIMARY KEY,
+	script_hash     TEXT,
+	change          TEXT,
+	project         TEXT,
+	note            TEXT,
+	committed_at    TIMESTAMP,
+	committer_name  TEXT,
+	committer_email TEXT,
+	planned_at      TIMESTAMP,
+	planner_name    TEXT,
+	planner_email   TEXT
+)
+WITH COMMENT = 'Tracks the changes currently deployed to the database.',
+AND CACHING = {
+	'keys': 'NONE',
+	'rows_per_partition': 'NONE'
+},
+AND GC_GRACE_SECONDS = 0,
+AND COMPRESSION = {
+	'class': 'LZ4Compressor'
+},
+AND CLUSTERING ORDER BY (change_id);
+
+CREATE TABLE :"registry".tags (
+	tag_id          TEXT PRIMARY KEY,
+	tag             TEXT,
+	project         TEXT,
+	change_id       TEXT,
+	note            TEXT,
+	committed_at    TIMESTAMP,
+	committer_name  TEXT,
+	committer_email TEXT,
+	planned_at      TIMESTAMP,
+	planner_name    TEXT,
+	planner_email   TEXT
+)
+WITH COMMENT = 'Tracks the tags currently applied to the database.'
+AND CACHING = {
+	'keys': 'NONE',
+	'rows_per_partition': 'NONE'
+},
+AND GC_GRACE_SECONDS = 0,
+AND COMPRESSION = {
+	'class': 'LZ4Compressor'
+},
+AND CLUSTERING ORDER BY (tag_id);
+
+CREATE TABLE :"registry".dependencies (
+	change_id       TEXT,
+	type            TEXT,
+	dependency      TEXT,
+	dependency_id   TEXT,
+	PRIMARY KEY (change_id, dependency)
+)
+WITH COMMENT = 'Tracks the currently satisfied dependencies.',
+AND CACHING = {
+	'keys': 'NONE',
+	'rows_per_partition': 'NONE'
+},
+AND GC_GRACE_SECONDS = 0,
+AND COMPRESSION = {
+	'class': 'LZ4Compressor'
+},
+AND CLUSTERING ORDER BY (change_id);
+
+CREATE TABLE :"registry".events (
+    event           TEXT,
+    change_id       TEXT,
+    change          TEXT,
+    project         TEXT,
+    note            TEXT,
+    requires        LIST<TEXT>,
+    conflicts       LIST<TEXT>,
+    tags            LIST<TEXT>,
+    committed_at    TIMESTAMP,
+    committer_name  TEXT,
+    committer_email TEXT,
+    planned_at      TIMESTAMP,
+    planner_name    TEXT,
+    planner_email   TEXT,
+    PRIMARY KEY (change_id, committed_at)
+)
+WITH COMMENT = 'Contains full history of all deployment events.',
+AND CACHING = {
+	'keys': 'NONE',
+	'rows_per_partition': 'NONE'
+},
+AND GC_GRACE_SECONDS = 0,
+AND COMPRESSION = {
+	'class': 'LZ4Compressor'
+},
+AND CLUSTERING ORDER BY (change_id);
+
+CREATE FUNCTION :"registry".dt_format(dt TIMESTAMP)
+RETURNS NULL ON NULL INPUT
+RETURNS TEXT
+LANGUAGE java
+AS $$
+	return "year:"
+	+ new java.util.SimpleDateFormat("yyyy:").format(dt)
+	+ "month:"
+	+ new java.util.SimpleDateFormat("MM:").format(dt)
+	+ "day:"
+	+ new java.util.SimpleDateFormat("dd:").format(dt)
+	+ "hour:"
+	+ new java.util.SimpleDateFormat("HH:").format(dt)
+	+ "minute:"
+	+ new java.util.SimpleDateFormat("mm:").format(dt)
+	+ "second:"
+	+ new java.util.SimpleDateFormat("ss:").format(dt)
+	+ "time_zone:"
+	+ new java.util.SimpleDateFormat("z").format(dt);
+$$;

--- a/lib/App/Sqitch/Engine/cassandra.pm
+++ b/lib/App/Sqitch/Engine/cassandra.pm
@@ -1,0 +1,301 @@
+package App::Sqitch::Engine::cassandra;
+
+use 5.010;
+use Moo;
+use utf8;
+use Path::Class;
+use DBI;
+use Try::Tiny;
+use App::Sqitch::X qw(hurl);
+use Locale::TextDomain qw(App-Sqitch);
+use App::Sqitch::Plan::Change;
+use List::Util qw(first);
+use App::Sqitch::Types qw(DBH ArrayRef);
+use namespace::autoclean;
+
+extends 'App::Sqitch::Engine';
+
+our $VERSION = '0.9997';
+
+has _cqsql => (
+	is      => 'ro',
+	isa     => ArrayRef,
+	lazy    => 1,
+	default => sub {
+		my $self = shift;
+		my $uri = $self->uri;
+		my @ret = ($self->client);
+		for my $spec (
+			[ username => $self->username ],
+			[ keyspace => $self->dbname ],
+		)
+		{
+			push @ret, "--$spec->[0]" => $spec->[1] if $spec->[1];
+		}
+
+		push @ret => $self->_client_opts;
+
+		return \@ret;
+	},
+);
+
+sub _client_ops {
+	my $self = shift;
+	return (
+		'--ssql',
+		'--no-color',
+	);
+}
+
+sub cqsql {
+	@{ shift->_cqsql }
+}
+
+sub key    { 'cassandra' }
+sub name   { 'Cassandra' }
+sub driver { 'DBD::Cassandra 0.56' }
+sub default_client { 'cqlsh' }
+
+sub destination {
+	my $self = shift;
+	return $self->target->name if $self->target->name !~ /:/
+		|| $self->target->uri->dbname;
+}
+
+has dbh => (
+	is => 'rw',
+	isa => DBH,
+	lazy => 1,
+	default => sub {
+		my $self = shift;
+		$self->use_driver;
+
+		my $uri = $self->uri;
+		DBI->connect($uri->dbi_dsn, scalar $self->username, scalar $self->password, {
+			PrintError  => 0,
+			RaiseError  => 0,
+			AutoCommit  => 1,
+			HandleError => sub {
+				my ($err, $dbh) = @_;
+				$@ = $err;
+				@_ = ($dbh->state || 'DEV' => $dbh->errstr);
+				goto &hurl;
+			},
+			Callbacks   => {
+				connected => sub {
+					my $dbh = shift;
+					$dbh->set_err(undef, undef) if $dbh->err;
+					return;
+				},
+			},
+		});
+	}
+);
+
+with 'App::Sqitch::Role::DBIEngine';
+
+sub _ts_default {
+	q{toTimestamp(now())}
+}
+
+sub _ts2char_format {
+	my $self = shift;
+	my $schema = $self->registry;
+	"{schema}.dt_format(%s)";
+}
+
+sub _char2ts {
+	$_[1]->as_string(format => 'iso')
+}
+
+sub _listagg_format {
+	q{%s}
+}
+
+sub _no_table_error  {
+	0;
+}
+
+sub _regex_op { '=' }
+
+sub initialized {
+	my $self = shift;
+	return $self->dbh->selectcol_arrayref(q{
+		SELECT COUNT(*) FROM system_schema.keyspaces
+		 WHERE keyspace_name = ?
+	}, undef, $self->registry)->[0];
+}
+
+sub initialize {
+	my $self = shift;
+	my $schema = $self->registry;
+	hurl engine => __x(
+		'Sqitch schema "{schema}" already exists',
+		schema => $schema
+	) if $self->initialized;
+
+	$self->_run_registry_file(file(__FILE__)->dir->file('cassandra.cql'));
+	$self->_register_release;
+}
+
+sub run_file {
+	my ($self, $file) = @_;
+	$self->_run('--file' => $file);
+}
+
+sub run_verify {
+	my $self = shift;
+	my $meth = $self->can($self->sqitch->verbosity > 1? '_run' : '_capture');
+	$self->$meth(@_);
+}
+
+sub run_handle {
+	my ($self, $fh) = @_;
+	$self->_spool($fh);
+}
+
+sub run_upgrade {
+	shift->_run_registry_file(@_);
+}
+
+sub _run_registry_file {
+	my ($self, $file) = @_;
+	my $schema = $self->registry;
+
+	my $vline = $self->_probe('-e', 'SHOW VERSION');
+	my ($maj) = $vline =~ / Cassandra (\d+)\./;
+	# TODO how to use the $maj?
+
+	(my $sql = scalar $file->slurp) =~ s{:"registry"}{$schema}g;
+
+	require File::Temp;
+	my $fh = File::Temp->new;
+	print $fh $sql;
+	close $fh;
+
+	$self->_run('--file' => $fh->filename);
+}
+
+sub _run {
+	my $self = shift;
+	my $sqitch = $self->sqitch;
+
+	my @args = ($self->client);
+	push @args => @_;
+	push @args => $self->host;
+	push @args => $self->_port;
+
+	return $sqitch->run($self->cqlsh, @args);
+}
+
+sub _probe {
+	my $self = shift;
+	my $sqitch = $self->sqitch;
+
+	my @args = ($self->client);
+	push @args => @_;
+	push @args => $self->host;
+	push @args => $self->_port;
+
+	return $sqitch->probe($self->cqlsh, @args);
+}
+
+sub _spool {
+	my $self = shift;
+	my $fh = shift;
+	my $sqitch = $self->sqitch;
+
+	my @args = ($self->client);
+	push @args => @_;
+	push @args => $self->host;
+	push @args => $self->_port;
+
+	return $sqitch->spool($fh, $self->cqlsh, @args);
+}
+
+sub _capture {
+	my $self = shift;
+	my $fh = shift;
+	my $sqitch = $self->sqitch;
+
+	my @args = ($self->client);
+	push @args => @_;
+	push @args => $self->host;
+	push @args => $self->_port;
+
+	return $sqitch->spool($self->cqlsh, @args);
+}
+
+sub begin_work {
+	my $self = shift;
+	my $dbh = $self->dbh;
+
+	$dbh->do('CONSISTENCY ALL');
+	$dbh->begin_work;
+	return $self;
+}
+
+sub finish_work {
+	my $self = shift;
+	return $self;
+}
+
+1;
+
+__END__
+
+=head1 Name
+
+App::Sqitch::Engine::cassandra - Sqitch Cassandra Engine
+
+=head1 Synopsis
+
+  my $cassandra = App::Sqitch::Engine->load( engine => 'cassandra' );
+
+=head1 Description
+
+App::Sqitch::Engine::cassandra provides the Cassandra storage engine for Sqitch.
+It support Cassandra 3.
+
+=head1 Interface
+
+=head3 C<initialized>
+
+  $cassandra->initialize unless $cassandra->initialized;
+
+Returns true if the database has been initialized for Sqitch, and false if it
+has not.
+
+=head3 C<initialize>
+
+  $cassandra->initialize;
+
+Initializes a database for Sqitch by installing the Sqitch registry schema.
+
+=head1 Author
+
+Jan Viktorin <iviktorin@fit.vutbr.cz>
+
+=head1 License
+
+Copyright (c) 2017 Jan Viktorin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+=cur


### PR DESCRIPTION
Hello,

I am interested in including a support of the Cassandra engine into Sqitch. Here I am proposing an incomplete work. I am not a Perl programmer and nor an expert on databases and thus I did my best to write as much as I could.

Currently I am still unable to connect to the running Cassandra instance from Sqitch. I don't understand, how should I build the connection string. I could not find the right code that seems to be able to construct the `dbi:Cassandra:keyspace=...` like string for any other engine. The current runtime gives: 
```
Can't connect to data source 'dbname=testing' because I can't work out what driver to use (it doesn't seem to contain a 'dbi:driver:' prefix and the DBI_DRIVER env var is not set)
```
with configuration
```
[core]
  engine = cassandra
[engine "cassandra"]
  target = testing
[target "testing"]
  uri = db:cassandra:testing
```

I am also not sure how to implement the registry manipulations. The `App::Sqitch::Role::DBIEngine` requires some functions like `_ts_default`, etc. I could not find any documentation for this and I am not very sure what is expected there. Especially, the `_listagg_format`, `_no_table_error` and `_regex_op` are confusing for me. Moreover, there is no regex operator in Cassandra Query Language (probably, it can be implemented via some user-defined function).

I'd be glad if anybody can review the code or give some tips how to make it.