### PR TITLE
Fix the "conmand" typo in the docs for sqitch upgrade

### DIFF
--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1049,7 +1049,7 @@ sub _check_registry {
     ) if $newver < $oldver;
 
     hurl engine => __x(
-        'Registry is at version {old} but latest is {new}. Please run the "upgrade" conmand',
+        'Registry is at version {old} but latest is {new}. Please run the "upgrade" command',
         old => $oldver,
         new => $newver,
     ) if $newver > $oldver;

--- a/po/App-Sqitch.pot
+++ b/po/App-Sqitch.pot
@@ -936,7 +936,7 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
-"conmand"
+"command"
 msgstr ""
 
 #: lib/App/Sqitch/Engine.pm:1067

--- a/po/de.po
+++ b/po/de.po
@@ -936,7 +936,7 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
-"conmand"
+"command"
 msgstr ""
 
 #: lib/App/Sqitch/Engine.pm:1067

--- a/po/fr.po
+++ b/po/fr.po
@@ -956,7 +956,7 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
-"conmand"
+"command"
 msgstr ""
 
 #: lib/App/Sqitch/Engine.pm:1067

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -981,7 +981,7 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
-"conmand"
+"command"
 msgstr ""
 "La versione di registro è {old} ma {new} è la più recente conosciuta. Per "
 "favore esegui il comando \"upgrade\"."

--- a/t/engine.t
+++ b/t/engine.t
@@ -290,7 +290,7 @@ throws_ok { $engine->_check_registry } 'App::Sqitch::X',
     'Should get error for out-of-date registry';
 is $@->ident, 'engine', 'Out-of-date registry error ident should be "engine"';
 is $@->message, __x(
-    'Registry is at version {old} but latest is {new}. Please run the "upgrade" conmand',
+    'Registry is at version {old} but latest is {new}. Please run the "upgrade" command',
     old => 0.1,
     new => $engine->registry_release,
 ), 'Out-of-date registry error message should be correct';


### PR DESCRIPTION
In the error message for an outdated sqitch registry the user is prompted to run the "conmand" `sqitch upgrade`. This typo occurred on multiple locations. I guess this is just a copy & pasted typo so I fixed it. 