### PR TITLE
Quote mysql.exe calls on Windows correctly because IPC::S::S doesn't.

### DIFF
--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -358,7 +358,7 @@ sub run {
         ( my $msg = shift ) =~ s/\s+at\s+.+/\n/ms;
         die $msg;
     };
-    runx @_;
+    runx $^O eq 'MSWin32' ? ( shift, $self->quote_shell(@_) ) : @_;
     return $self;
 }
 


### PR DESCRIPTION
run() here calls IPC::S::S' runx(), which has two paths. On non-windows systems it calls `system { $command } $command, @args` which works just fine even with complex stuff in the args. On Windows however it calls `_spawn_or_die($command, "$command @args")`, which smashes all the arguments together separated by spaces without *any* additional quoting. This results in a garbage process call which mysql consequently rewards with RTFM.

This fix quotes the arguments on windows, and takes care to leave the executable name separate to allow proper naming of the created process object.

fixes #262