### PR TITLE
Report uninitialized project, not missing engine.

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Revision history for Perl extension App::Sqitch
      - Fixed a Snowflake engine error where it failed to recognize the proper
        error code for a missing table and therefore an uninitialized registry.
        Thanks to @lerouxt and @kulmam92 for the report and fix (#439).
+     - Added check for project initialization when no engine config can be
+       found. Now reports that the project is not initialized instead of
+       complaining about no engine config when run from a directory with no
+       Sqitch configuration (#437).
 
 0.9999 2019-02-01T15:29:40Z
      [Bug Fixes]

--- a/lib/App/Sqitch/Config.pm
+++ b/lib/App/Sqitch/Config.pm
@@ -73,6 +73,24 @@ sub initial_key {
     return ref $key ? $key->[0] : $key;
 }
 
+sub initialized {
+    my $self = shift;
+    $self->load unless $self->is_loaded;
+    return $self->{_initialized};
+}
+
+sub load_dirs {
+    my $self = shift;
+    local $self->{__loading_dirs} = 1;
+    $self->SUPER::load_dirs(@_);
+}
+
+sub load_file {
+    my $self = shift;
+    $self->{_initialized} ||= $self->{__loading_dirs};
+    $self->SUPER::load_file(@_);
+}
+
 1;
 
 =head1 Name
@@ -134,6 +152,14 @@ will be returned.
 =head3 C<dir_file>
 
 An alias for C<local_file()> for use by the parent class.
+
+=head3 C<initialized>
+
+  say 'Project not initialized' unless $config->initialized;
+
+Returns true if the project configuration file was found, and false if it was
+not. Useful for detecting when a command has been run from a directory with no
+Sqitch configuration.
 
 =head3 C<get_section>
 

--- a/lib/App/Sqitch/Engine/snowflake.pm
+++ b/lib/App/Sqitch/Engine/snowflake.pm
@@ -67,7 +67,7 @@ has _snowcfg => (
         return {} if not $hd;
         my $fn = dir $hd, '.snowsql', 'config';
         return {} unless -e $fn;
-        my $data = App::Sqitch::Config->load_file($fn);
+        my $data = App::Sqitch::Config->new->load_file($fn);
         my $cfg = {};
         for my $k (keys %{ $data }) {
             # We only want the default connections config. No named config.

--- a/lib/App/Sqitch/Target.pm
+++ b/lib/App/Sqitch/Target.pm
@@ -246,11 +246,14 @@ sub BUILDARGS {
             }
 
             # No core target, look for an engine key.
-            $ekey = $config->get(
-                key => 'core.engine'
-            ) or hurl target => __(
-                'No engine specified; specify via target or core.engine'
-            );
+            $ekey = $config->get( key => 'core.engine' ) or do {
+                hurl target => __(
+                    'No engine specified; specify via target or core.engine'
+                ) if $config->initialized;
+                hurl target => __(
+                    'No project configuration found. Run the "init" command to initialize a project'
+                );
+            };
             $ekey =~ s/\s+$//;
 
             # Find the name in the engine config, or fall back on a simple URI.

--- a/t/command.t
+++ b/t/command.t
@@ -528,8 +528,8 @@ ARGS: {
             'Should have error for no engine or target';
         is $@->ident, 'target', 'Should have target ident';
         is $@->message, __(
-            'No engine specified; specify via target or core.engine',
-        ), 'Should have message about no specified engine';
+            'No project configuration found. Run the "init" command to initialize a project',
+        ), 'Should have message about no config';
 
         # But it should be okay if we pass an engine or valid target.
         is_deeply $parsem->(args => ['pg']),

--- a/t/configuration.t
+++ b/t/configuration.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 17;
+use Test::More tests => 20;
 #use Test::More 'no_plan';
 use File::Spec;
 use Test::Exception;
@@ -19,6 +19,7 @@ delete @ENV{qw( SQITCH_CONFIG SQITCH_USER_CONFIG SQITCH_SYSTEM_CONFIG )};
 
 isa_ok my $config = $CLASS->new, $CLASS, 'New config object';
 is $config->confname, 'sqitch.conf', 'confname should be "sqitch.conf"';
+ok !$config->initialized, 'Should not be initialized';
 
 my $hd = $^O eq 'MSWin32' && "$]" < '5.016' ? $ENV{HOME} || $ENV{USERPROFILE} : (glob('~'))[0];
 
@@ -63,6 +64,8 @@ SQITCH_CONFIG: {
 }
 
 chdir 't';
+isa_ok $config = $CLASS->new, $CLASS, 'Another config object';
+ok $config->initialized, 'Should be initialized';
 is_deeply $config->get_section(section => 'core'), {
     engine    => "pg",
     extension => "ddl",
@@ -74,4 +77,3 @@ is_deeply $config->get_section(section => 'core'), {
 is_deeply $config->get_section(section => 'engine.pg'), {
     client => "/usr/local/pgsql/bin/psql",
 }, 'get_section("engine.pg") should work';
-

--- a/t/target.t
+++ b/t/target.t
@@ -208,8 +208,19 @@ CONSTRUCTOR: {
         'Should have error for no engine or target';
     is $@->ident, 'target', 'Should have target ident';
     is $@->message, __(
-        'No engine specified; specify via target or core.engine',
-    ), 'Should have message about no specified engine';
+        'No project configuration found. Run the "init" command to initialize a project',
+    ), 'Should have message about no configuration';
+
+    # Try it with a config file but no engine config.
+    MOCK: {
+        my $mock_init = TestConfig->mock(initialized => 1);
+        throws_ok { $CLASS->new(sqitch => $sqitch) } 'App::Sqitch::X',
+            'Should again have error for no engine or target';
+        is $@->ident, 'target', 'Should have target ident again';
+        is $@->message, __(
+            'No engine specified; specify via target or core.engine',
+        ), 'Should have message about no specified engine';
+    }
 
     # Try with engine-less URI.
     @get_params = ();


### PR DESCRIPTION
When attempting to do something like deploy from a directory where not
relevant config can be found.

To make it work, add an `initialized` method to App::Sqitch::Config and
subclass the necessary instance methods to make it return true when a
directory config file has been found.

Closes #437.