### PR TITLE
Replace ask_y_n() with ask_yes_no().

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,6 +31,11 @@ Revision history for Perl extension App::Sqitch
        request (#451).
      - Renamed the French localization from "fr" to "fr_FR", so that systems
        will actually find it.
+     - Added the `ask_yes_no()` method as a reaplcement for `ask_y_n()`, which
+       is now deprecated. The new method expects localized responses from the
+       user when translations are provided. Defaults to the English "yes" and
+       "no" when no translation is available. Suggested by German translator
+       Thomas Iguchi (#449).
 
 0.9999 2019-02-01T15:29:40Z
      [Bug Fixes]

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -300,11 +300,11 @@ sub revert {
                 ident   => 'revert:confirm',
                 message => __ 'Nothing reverted',
                 exitval => 1,
-            } unless $sqitch->ask_y_n(__x(
+            } unless $sqitch->ask_yes_no(__x(
                 'Revert changes to {change} from {destination}?',
                 change      => $change->format_name_with_tags,
                 destination => $self->destination,
-            ), $self->prompt_accept ? 'Yes' : 'No' );
+            ), $self->prompt_accept );
         }
 
     } else {
@@ -323,10 +323,10 @@ sub revert {
                 ident   => 'revert',
                 message => __ 'Nothing reverted',
                 exitval => 1,
-            } unless $sqitch->ask_y_n(__x(
+            } unless $sqitch->ask_yes_no(__x(
                 'Revert all changes from {destination}?',
                 destination => $self->destination,
-            ), $self->prompt_accept ? 'Yes' : 'No' );
+            ), $self->prompt_accept );
         }
     }
 

--- a/po/App-Sqitch.pot
+++ b/po/App-Sqitch.pot
@@ -43,6 +43,16 @@ msgid ""
 "Sqitch seems to be unattended and there is no default value for this question"
 msgstr ""
 
+#: lib/App/Sqitch.pm:428
+msgctxt "Confirm prompt answer yes"
+msgid "Yes"
+msgstr ""
+
+#: lib/App/Sqitch.pm:429
+msgctxt "Confirm prompt answer no"
+msgid "No"
+msgstr ""
+
 #: lib/App/Sqitch.pm:438
 msgid "Please answer \"y\" or \"n\"."
 msgstr ""

--- a/po/App-Sqitch.pot
+++ b/po/App-Sqitch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: App-Sqitch 0.9999\n"
+"Project-Id-Version: App-Sqitch v1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-25 10:09-0500\n"
+"POT-Creation-Date: 2019-04-23 10:11-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -61,17 +61,17 @@ msgstr ""
 msgid "No valid answer after 3 attempts; aborting"
 msgstr ""
 
-#: lib/App/Sqitch.pm:451 lib/App/Sqitch.pm:458
+#: lib/App/Sqitch.pm:462 lib/App/Sqitch.pm:469
 #, perl-brace-format
 msgid "Cannot exec {command}: {error}"
 msgstr ""
 
-#: lib/App/Sqitch.pm:474
+#: lib/App/Sqitch.pm:485
 #, perl-brace-format
 msgid "Error closing pipe to {command}: {error}"
 msgstr ""
 
-#: lib/App/Sqitch.pm:478 lib/App/Sqitch/Engine/oracle.pm:758
+#: lib/App/Sqitch.pm:489 lib/App/Sqitch/Engine/oracle.pm:758
 #, perl-brace-format
 msgid "{command} unexpectedly returned exit value {exitval}"
 msgstr ""
@@ -641,12 +641,12 @@ msgstr ""
 msgid "URI"
 msgstr ""
 
-#: lib/App/Sqitch/Command/upgrade.pm:49
+#: lib/App/Sqitch/Command/upgrade.pm:48
 #, perl-brace-format
 msgid "Upgrading registry {registry} to version {version}"
 msgstr ""
 
-#: lib/App/Sqitch/Command/upgrade.pm:56
+#: lib/App/Sqitch/Command/upgrade.pm:55
 #, perl-brace-format
 msgid "Registry {registry} is up-to-date at version {version}"
 msgstr ""
@@ -656,7 +656,7 @@ msgstr ""
 msgid "Too many changes specified; verifying from \"{from}\" to \"{to}\""
 msgstr ""
 
-#: lib/App/Sqitch/Config.pm:26
+#: lib/App/Sqitch/Config.pm:25
 msgid "Could not determine home directory"
 msgstr ""
 
@@ -666,7 +666,7 @@ msgid "Unknown date format \"{format}\""
 msgstr ""
 
 #: lib/App/Sqitch/Engine.pm:133 lib/App/Sqitch/Engine.pm:145
-#: lib/App/Sqitch/Target.pm:252
+#: lib/App/Sqitch/Target.pm:251
 msgid "No engine specified; specify via target or core.engine"
 msgstr ""
 
@@ -1414,17 +1414,23 @@ msgid ""
 "Cannot initialize because project \"{project}\" already initialized in {file}"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:273
+#: lib/App/Sqitch/Target.pm:254
+msgid ""
+"No project configuration found. Run the \"init\" command to initialize a "
+"project"
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:276
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:279
+#: lib/App/Sqitch/Target.pm:282
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:288
+#: lib/App/Sqitch/Target.pm:291
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sqitch 0.932\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-25 10:09-0500\n"
+"POT-Creation-Date: 2019-04-23 10:11-0400\n"
 "PO-Revision-Date: 2012-08-31 17:15-0700\n"
 "Last-Translator: Thomas Iguchi <ti@nobu-games.com>\n"
 "Language-Team: German <david@justatheory.com>\n"
@@ -67,17 +67,17 @@ msgstr "Bitte antworte mit \"j\" oder \"n\""
 msgid "No valid answer after 3 attempts; aborting"
 msgstr "Drei ungültige Antworten in Folge. Breche ab"
 
-#: lib/App/Sqitch.pm:451 lib/App/Sqitch.pm:458
+#: lib/App/Sqitch.pm:462 lib/App/Sqitch.pm:469
 #, perl-brace-format
 msgid "Cannot exec {command}: {error}"
 msgstr "Konnte den Befehl {command} nicht ausführen: {error}"
 
-#: lib/App/Sqitch.pm:474
+#: lib/App/Sqitch.pm:485
 #, perl-brace-format
 msgid "Error closing pipe to {command}: {error}"
 msgstr "Fehler beim Schließen der Pipeline nach {command}: {error}"
 
-#: lib/App/Sqitch.pm:478 lib/App/Sqitch/Engine/oracle.pm:758
+#: lib/App/Sqitch.pm:489 lib/App/Sqitch/Engine/oracle.pm:758
 #, perl-brace-format
 msgid "{command} unexpectedly returned exit value {exitval}"
 msgstr "{command} brach unerwartet ab mit Rückgabewert {exitval}"
@@ -682,12 +682,12 @@ msgstr ""
 msgid "URI"
 msgstr "URI"
 
-#: lib/App/Sqitch/Command/upgrade.pm:49
+#: lib/App/Sqitch/Command/upgrade.pm:48
 #, perl-brace-format
 msgid "Upgrading registry {registry} to version {version}"
 msgstr "Aktualisiere Registry {registry} nach Version {version}"
 
-#: lib/App/Sqitch/Command/upgrade.pm:56
+#: lib/App/Sqitch/Command/upgrade.pm:55
 #, perl-brace-format
 msgid "Registry {registry} is up-to-date at version {version}"
 msgstr "Registry {registry} auf Version {version} aktualisiert"
@@ -698,7 +698,7 @@ msgid "Too many changes specified; verifying from \"{from}\" to \"{to}\""
 msgstr ""
 "Zu viele Änderungen angegeben. Verifiziere von \"{from}\" nach \"{to}\""
 
-#: lib/App/Sqitch/Config.pm:26
+#: lib/App/Sqitch/Config.pm:25
 msgid "Could not determine home directory"
 msgstr "Konnte Benutzerverzeichnis nicht finden"
 
@@ -708,7 +708,7 @@ msgid "Unknown date format \"{format}\""
 msgstr "Unbekanntes Datumsformat \"{format}\""
 
 #: lib/App/Sqitch/Engine.pm:133 lib/App/Sqitch/Engine.pm:145
-#: lib/App/Sqitch/Target.pm:252
+#: lib/App/Sqitch/Target.pm:251
 msgid "No engine specified; specify via target or core.engine"
 msgstr ""
 "Keine Engine angegeben. Bitte gib eine via \"target\" oder \"core.engine\" an"
@@ -1375,8 +1375,8 @@ msgstr ""
 #: lib/App/Sqitch/Plan.pm:908
 #, perl-brace-format
 msgid ""
-"\"{name}\" is invalid: changes must not begin with punctuation, contain "
-"\"@\", \":\", \"#\", or blanks, or end in punctuation or digits following "
+"\"{name}\" is invalid: changes must not begin with punctuation, contain \"@"
+"\", \":\", \"#\", or blanks, or end in punctuation or digits following "
 "punctuation"
 msgstr ""
 "\"{name}\" ist ungültig. Änderungen dürfen nicht mit Satzzeichen beginnen, "
@@ -1529,17 +1529,23 @@ msgstr ""
 "Kann nicht initialisieren da Projekt \"{project}\" bereits in {file} "
 "initialisiert wurde"
 
-#: lib/App/Sqitch/Target.pm:273
+#: lib/App/Sqitch/Target.pm:254
+msgid ""
+"No project configuration found. Run the \"init\" command to initialize a "
+"project"
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:276
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr "Kann Ziel \"{target}\" nicht finden"
 
-#: lib/App/Sqitch/Target.pm:279
+#: lib/App/Sqitch/Target.pm:282
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr "Keine URI mit Ziel \"{target}\" verknüpft"
 
-#: lib/App/Sqitch/Target.pm:288
+#: lib/App/Sqitch/Target.pm:291
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sqitch 0.932\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-25 10:09-0500\n"
+"POT-Creation-Date: 2019-04-23 10:11-0400\n"
 "PO-Revision-Date: 2012-10-12 11:28-0700\n"
 "Last-Translator: Arnaud Assad <arhuman@gmail.com>\n"
 "Language-Team: French <arhuman@gmail.com>\n"
@@ -45,6 +45,16 @@ msgid ""
 "Sqitch seems to be unattended and there is no default value for this question"
 msgstr ""
 
+#: lib/App/Sqitch.pm:428
+msgctxt "Confirm prompt answer yes"
+msgid "Yes"
+msgstr ""
+
+#: lib/App/Sqitch.pm:429
+msgctxt "Confirm prompt answer no"
+msgid "No"
+msgstr ""
+
 #: lib/App/Sqitch.pm:438
 msgid "Please answer \"y\" or \"n\"."
 msgstr ""
@@ -53,17 +63,17 @@ msgstr ""
 msgid "No valid answer after 3 attempts; aborting"
 msgstr ""
 
-#: lib/App/Sqitch.pm:451 lib/App/Sqitch.pm:458
+#: lib/App/Sqitch.pm:462 lib/App/Sqitch.pm:469
 #, perl-brace-format
 msgid "Cannot exec {command}: {error}"
 msgstr "Impossible d'exécuter {command} : {error}"
 
-#: lib/App/Sqitch.pm:474
+#: lib/App/Sqitch.pm:485
 #, perl-brace-format
 msgid "Error closing pipe to {command}: {error}"
 msgstr "Erreur en fermant le tube vers {command} : {error}"
 
-#: lib/App/Sqitch.pm:478 lib/App/Sqitch/Engine/oracle.pm:758
+#: lib/App/Sqitch.pm:489 lib/App/Sqitch/Engine/oracle.pm:758
 #, perl-brace-format
 msgid "{command} unexpectedly returned exit value {exitval}"
 msgstr "{command} a retourné de manière inattendue la valeur {exitval}"
@@ -642,12 +652,12 @@ msgstr ""
 msgid "URI"
 msgstr ""
 
-#: lib/App/Sqitch/Command/upgrade.pm:49
+#: lib/App/Sqitch/Command/upgrade.pm:48
 #, fuzzy, perl-brace-format
 msgid "Upgrading registry {registry} to version {version}"
 msgstr "Ajout des tables de metadonnées à {destination}"
 
-#: lib/App/Sqitch/Command/upgrade.pm:56
+#: lib/App/Sqitch/Command/upgrade.pm:55
 #, perl-brace-format
 msgid "Registry {registry} is up-to-date at version {version}"
 msgstr ""
@@ -657,7 +667,7 @@ msgstr ""
 msgid "Too many changes specified; verifying from \"{from}\" to \"{to}\""
 msgstr ""
 
-#: lib/App/Sqitch/Config.pm:26
+#: lib/App/Sqitch/Config.pm:25
 msgid "Could not determine home directory"
 msgstr "Impossible de déterminer le répertoire de référence"
 
@@ -667,7 +677,7 @@ msgid "Unknown date format \"{format}\""
 msgstr "Format de date inconnu \"{format}\""
 
 #: lib/App/Sqitch/Engine.pm:133 lib/App/Sqitch/Engine.pm:145
-#: lib/App/Sqitch/Target.pm:252
+#: lib/App/Sqitch/Target.pm:251
 #, fuzzy
 msgid "No engine specified; specify via target or core.engine"
 msgstr "Pas de moteur spécifié; utiliser --engine ou définir core.engine"
@@ -1468,17 +1478,23 @@ msgid ""
 "Cannot initialize because project \"{project}\" already initialized in {file}"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:273
+#: lib/App/Sqitch/Target.pm:254
+msgid ""
+"No project configuration found. Run the \"init\" command to initialize a "
+"project"
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:276
 #, fuzzy, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr "Impossible de trouver le changement {change}"
 
-#: lib/App/Sqitch/Target.pm:279
+#: lib/App/Sqitch/Target.pm:282
 #, fuzzy, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr "Cible d'annulation inconnue : \"{target}\""
 
-#: lib/App/Sqitch/Target.pm:288
+#: lib/App/Sqitch/Target.pm:291
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: App-Sqitch 0.9996\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-25 10:09-0500\n"
+"POT-Creation-Date: 2019-04-23 10:11-0400\n"
 "PO-Revision-Date: 2017-10-12 10:30+0200\n"
 "Last-Translator: Luca Ferrari <fluca1978@gmail.com>\n"
 "Language-Team: Italian <fluca1978@gmail.com>\n"
@@ -48,6 +48,16 @@ msgid ""
 msgstr ""
 "Sqitch sembra non presidiato e non ha un valore di default per il quesito"
 
+#: lib/App/Sqitch.pm:428
+msgctxt "Confirm prompt answer yes"
+msgid "Yes"
+msgstr ""
+
+#: lib/App/Sqitch.pm:429
+msgctxt "Confirm prompt answer no"
+msgid "No"
+msgstr ""
+
 #: lib/App/Sqitch.pm:438
 msgid "Please answer \"y\" or \"n\"."
 msgstr "Rispondi \"y\" (si) o \"n\" (no)"
@@ -56,17 +66,17 @@ msgstr "Rispondi \"y\" (si) o \"n\" (no)"
 msgid "No valid answer after 3 attempts; aborting"
 msgstr "Nessuna risposta valida in 3 tentativi, aborto"
 
-#: lib/App/Sqitch.pm:451 lib/App/Sqitch.pm:458
+#: lib/App/Sqitch.pm:462 lib/App/Sqitch.pm:469
 #, perl-brace-format
 msgid "Cannot exec {command}: {error}"
 msgstr "Non posso eseguire {command}: {error}"
 
-#: lib/App/Sqitch.pm:474
+#: lib/App/Sqitch.pm:485
 #, perl-brace-format
 msgid "Error closing pipe to {command}: {error}"
 msgstr "Errore di chiusura pipe per {command}: {error}"
 
-#: lib/App/Sqitch.pm:478 lib/App/Sqitch/Engine/oracle.pm:758
+#: lib/App/Sqitch.pm:489 lib/App/Sqitch/Engine/oracle.pm:758
 #, perl-brace-format
 msgid "{command} unexpectedly returned exit value {exitval}"
 msgstr "Il comando {command} ha restituito un exit value inatteso {exitval}"
@@ -659,12 +669,12 @@ msgstr ""
 msgid "URI"
 msgstr "URI"
 
-#: lib/App/Sqitch/Command/upgrade.pm:49
+#: lib/App/Sqitch/Command/upgrade.pm:48
 #, perl-brace-format
 msgid "Upgrading registry {registry} to version {version}"
 msgstr "Aggiorno il registro {registry} alla versione {version}"
 
-#: lib/App/Sqitch/Command/upgrade.pm:56
+#: lib/App/Sqitch/Command/upgrade.pm:55
 #, perl-brace-format
 msgid "Registry {registry} is up-to-date at version {version}"
 msgstr "Il registro {registry} è aggiornato alla versione {version}"
@@ -674,7 +684,7 @@ msgstr "Il registro {registry} è aggiornato alla versione {version}"
 msgid "Too many changes specified; verifying from \"{from}\" to \"{to}\""
 msgstr "Troppe modifiche specificate; verfica da \"{from}\" a \"{to}\""
 
-#: lib/App/Sqitch/Config.pm:26
+#: lib/App/Sqitch/Config.pm:25
 msgid "Could not determine home directory"
 msgstr "Non riesco a stabiliare la home directory"
 
@@ -684,7 +694,7 @@ msgid "Unknown date format \"{format}\""
 msgstr "Formato data \"{format}\" sconosciuto"
 
 #: lib/App/Sqitch/Engine.pm:133 lib/App/Sqitch/Engine.pm:145
-#: lib/App/Sqitch/Target.pm:252
+#: lib/App/Sqitch/Target.pm:251
 #, fuzzy
 msgid "No engine specified; specify via target or core.engine"
 msgstr "Nessun motore specificato: usa --engine o imposta core.engine"
@@ -1505,17 +1515,23 @@ msgstr ""
 "Impossibile inizializzare poiché il progetto \"{project}\" è già stato "
 "inizializzato in {file}"
 
-#: lib/App/Sqitch/Target.pm:273
+#: lib/App/Sqitch/Target.pm:254
+msgid ""
+"No project configuration found. Run the \"init\" command to initialize a "
+"project"
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:276
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr "Non posso trovare il target specificato \"{target}\""
 
-#: lib/App/Sqitch/Target.pm:279
+#: lib/App/Sqitch/Target.pm:282
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr "Nessun URI associato al target \"{target}\""
 
-#: lib/App/Sqitch/Target.pm:288
+#: lib/App/Sqitch/Target.pm:291
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/t/base.t
+++ b/t/base.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 158;
+use Test::More tests => 189;
 #use Test::More 'no_plan';
 use Test::MockModule 0.17;
 use Path::Class;
@@ -28,6 +28,7 @@ can_ok $CLASS, qw(
     user_email
     verbosity
     prompt
+    ask_yes_no
     ask_y_n
 );
 
@@ -536,12 +537,69 @@ is capture_stdout {
 }, "hi [yo] yo\n", 'Prompt should show default as selected when unattended';
 
 ##############################################################################
+# Test ask_yes_no().
+throws_ok { $sqitch->ask_yes_no } 'App::Sqitch::X',
+    'Should get error for no ask_yes_no message';
+is $@->ident, 'DEV', 'No ask_yes_no ident should be "DEV"';
+is $@->message, 'ask_yes_no() called without a prompt message',
+    'No ask_yes_no error message should be correct';
+
+my $yes = __ 'Yes';
+my $no = __ 'No';
+
+# Test affermation.
+for my $variant ($yes, lc $yes, uc $yes, lc substr($yes, 0, 1), substr($yes, 0, 2)) {
+    $input = $variant;
+    $unattended = 0;
+    is capture_stdout {
+        ok $sqitch->ask_yes_no('hi'),
+            qq{ask_yes_no() should return true for "$variant" input};
+    }, 'hi ', qq{ask_yes_no() should prompt for "$variant"};
+}
+
+# Test negation.
+for my $variant ($no, lc $no, uc $no, lc substr($no, 0, 1), substr($no, 0, 2)) {
+    $input = $variant;
+    $unattended = 0;
+    is capture_stdout {
+        ok !$sqitch->ask_yes_no('hi'),
+            qq{ask_yes_no() should return false for "$variant" input};
+    }, 'hi ', qq{ask_yes_no() should prompt for "$variant"};
+}
+
+# Test defaults.
+$input = '';
+is capture_stdout {
+    ok $sqitch->ask_yes_no('whu?', 1),
+        'ask_yes_no() should return true for true default'
+}, "whu? [$yes] ", 'ask_yes_no() should prompt and show default "Yes"';
+is capture_stdout {
+    ok !$sqitch->ask_yes_no('whu?', 0),
+        'ask_yes_no() should return false for false default'
+}, "whu? [$no] ", 'ask_yes_no() should prompt and show default "No"';
+
+my $please = __ 'Please answer "y" or "n".';
+$input = 'ha!';
+throws_ok {
+    is capture_stdout { $sqitch->ask_yes_no('hi')  },
+        "hi  \n$please\nhi  \n$please\nhi  \n",
+         'Should get prompts for repeated bad answers';
+} 'App::Sqitch::X', 'Should get error for bad answers';
+is $@->ident, 'io', 'Bad answers ident should be "IO"';
+is $@->message, __ 'No valid answer after 3 attempts; aborting',
+    'Bad answers message should be correct';
+
+##############################################################################
 # Test ask_y_n().
+my $warning;
+$sqitch_mock->mock(warn => sub { shift; $warning = "@_" });
 throws_ok { $sqitch->ask_y_n } 'App::Sqitch::X',
     'Should get error for no ask_y_n message';
 is $@->ident, 'DEV', 'No ask_y_n ident should be "DEV"';
-is $@->message, 'ask_y_n() called without a prompt message',
+is $@->message, 'ask_yes_no() called without a prompt message',
     'No ask_y_n error message should be correct';
+is $warning, 'The ask_y_n() method has been deprecated. Use ask_yes_no() instead.',
+    'Should get a deprecation warning from ask_y_n';
 
 throws_ok { $sqitch->ask_y_n('hi', 'b') } 'App::Sqitch::X',
     'Should get error for invalid ask_y_n default';
@@ -549,36 +607,42 @@ is $@->ident, 'DEV', 'Invalid ask_y_n default ident should be "DEV"';
 is $@->message, 'Invalid default value: ask_y_n() default must be "y" or "n"',
     'Invalid ask_y_n default error message should be correct';
 
-$input = 'y';
+$input = lc substr $yes, 0, 1;
 $unattended = 0;
 is capture_stdout {
-    ok $sqitch->ask_y_n('hi'), 'ask_y_n should return true for "y" input';
+    ok $sqitch->ask_y_n('hi'),
+        qq{ask_y_n should return true for "$input" input}
 }, 'hi ', 'ask_y_n() should prompt';
 
-$input = 'no';
+$input = lc substr $no, 0, 1;
 is capture_stdout {
-    ok !$sqitch->ask_y_n('howdy'), 'ask_y_n should return false for "no" input';
+    ok !$sqitch->ask_y_n('howdy'),
+        qq{ask_y_n should return false for "$input" input}
 }, 'howdy ', 'ask_y_n() should prompt for no';
 
-$input = 'Nein';
+$input = uc substr $no, 0, 1;
 is capture_stdout {
-    ok !$sqitch->ask_y_n('howdy'), 'ask_y_n should return false for "Nein"';
+    ok !$sqitch->ask_y_n('howdy'),
+        qq{ask_y_n should return false for "$input" input}
 }, 'howdy ', 'ask_y_n() should prompt for no';
 
-$input = 'Yep';
+$input = uc substr $yes, 0, 2;
 is capture_stdout {
-    ok $sqitch->ask_y_n('howdy'), 'ask_y_n should return true for "Yep"';
+    ok $sqitch->ask_y_n('howdy'),
+        qq{ask_y_n should return true for "$input" input}
 }, 'howdy ', 'ask_y_n() should prompt for yes';
 
 $input = '';
 is capture_stdout {
-    ok $sqitch->ask_y_n('whu?', 'y'), 'ask_y_n should return true default "y"';
-}, 'whu? [y] ', 'ask_y_n() should prompt and show default "y"';
-is capture_stdout {
-    ok !$sqitch->ask_y_n('whu?', 'n'), 'ask_y_n should return false default "n"';
-}, 'whu? [n] ', 'ask_y_n() should prompt and show default "n"';
+    ok $sqitch->ask_y_n('whu?', 'y'),
+        qq{ask_y_n should return true default "$yes"}
+}, "whu? [$yes] ", 'ask_y_n() should prompt and show default "Yes"';
 
-my $please = __ 'Please answer "y" or "n".';
+is capture_stdout {
+    ok !$sqitch->ask_y_n('whu?', 'n'),
+        qq{ask_y_n should return false default "$no"};
+}, "whu? [$no] ", 'ask_y_n() should prompt and show default "No"';
+
 $input = 'ha!';
 throws_ok {
     is capture_stdout { $sqitch->ask_y_n('hi')  },

--- a/t/engine.t
+++ b/t/engine.t
@@ -1859,7 +1859,7 @@ my @dbchanges;
     $params;
 } @changes[0..3];
 
-MockOutput->ask_y_n_returns(1);
+MockOutput->ask_yes_no_returns(1);
 ok $engine->revert, 'Revert all changes';
 is_deeply $engine->seen, [
     [deployed_changes => undef],
@@ -1873,11 +1873,11 @@ is_deeply $engine->seen, [
     [run_file => $dbchanges[0]->revert_file ],
     [log_revert_change => $dbchanges[0] ],
 ], 'Should have reverted the changes in reverse order';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert all changes from {destination}?',
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompted to revert all changes';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -1904,11 +1904,11 @@ is_deeply $engine->seen, [
     [log_revert_change => $dbchanges[1] ],
     [log_revert_change => $dbchanges[0] ],
 ], 'Log-only Should have reverted the changes in reverse order';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert all changes from {destination}?',
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Log-only should have prompted to revert all changes';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -1924,7 +1924,7 @@ is_deeply +MockOutput->get_info, [
 ], 'And the revert successes should be emitted';
 
 # Should exit if the revert is declined.
-MockOutput->ask_y_n_returns(0);
+MockOutput->ask_yes_no_returns(0);
 throws_ok { $engine->revert } 'App::Sqitch::X', 'Should abort declined revert';
 is $@->ident, 'revert', 'Declined revert ident should be "revert"';
 is $@->exitval, 1, 'Should have exited with value 1';
@@ -1932,17 +1932,17 @@ is $@->message, __ 'Nothing reverted', 'Should have exited with proper message';
 is_deeply $engine->seen, [
     [deployed_changes => undef],
 ], 'Should have called deployed_changes only';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert all changes from {destination}?',
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompt to revert all changes';
 is_deeply +MockOutput->get_info, [
 ], 'It should have emitted nothing else';
 
 # Revert all changes with no prompt.
-MockOutput->ask_y_n_returns(1);
+MockOutput->ask_yes_no_returns(1);
 $engine->log_only(0);
 $engine->no_prompt(1);
 ok $engine->revert, 'Revert all changes with no prompt';
@@ -1958,7 +1958,7 @@ is_deeply $engine->seen, [
     [run_file => $dbchanges[0]->revert_file ],
     [log_revert_change => $dbchanges[0] ],
 ], 'Should have reverted the changes in reverse order';
-is_deeply +MockOutput->get_ask_y_n, [], 'Should have no prompt';
+is_deeply +MockOutput->get_ask_yes_no, [], 'Should have no prompt';
 
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -1995,12 +1995,12 @@ is_deeply $engine->seen, [
     [run_file => $dbchanges[2]->revert_file ],
     [log_revert_change => $dbchanges[2] ],
 ], 'Should have reverted only changes after @alpha';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert changes to {change} from {destination}?',
         destination => $engine->destination,
         change      => $dbchanges[1]->format_name_with_tags,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompt to revert to change';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -2011,7 +2011,7 @@ is_deeply +MockOutput->get_info, [
     [__ 'ok'],
 ], 'And the revert successes should be emitted';
 
-MockOutput->ask_y_n_returns(0);
+MockOutput->ask_yes_no_returns(0);
 $offset_change = $dbchanges[1];
 push @resolved => $offset_change->id;
 throws_ok { $engine->revert('@alpha') } 'App::Sqitch::X',
@@ -2024,18 +2024,18 @@ is_deeply $engine->seen, [
     [change_offset_from_id => [$dbchanges[1]->id, 0] ],
     [deployed_changes_since => $dbchanges[1]],
 ], 'Should have called revert methods';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert changes to {change} from {destination}?',
         change      => $dbchanges[1]->format_name_with_tags,
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompt to revert to @alpha';
 is_deeply +MockOutput->get_info, [
 ], 'It should have emitted nothing else';
 
 # Try to revert just the last change with no prompt
-MockOutput->ask_y_n_returns(1);
+MockOutput->ask_yes_no_returns(1);
 $engine->no_prompt(1);
 my $rev_file = $dbchanges[-1]->revert_file; # Grab before deleting _rework_tags.
 my $rtags = delete $dbchanges[-1]->{_rework_tags}; # These need to be invisible.
@@ -2051,7 +2051,7 @@ is_deeply $engine->seen, [
     [run_file => $rev_file ],
     [log_revert_change => { %{ $dbchanges[-1] }, _rework_tags => $rtags } ],
 ], 'Should have reverted one changes for @HEAD^';
-is_deeply +MockOutput->get_ask_y_n, [], 'Should have no prompt';
+is_deeply +MockOutput->get_ask_yes_no, [], 'Should have no prompt';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '', ' '],
 ], 'Output should show what it reverts to';

--- a/t/lib/MockOutput.pm
+++ b/t/lib/MockOutput.pm
@@ -26,14 +26,14 @@ my @mocked = qw(
     page
     page_literal
     prompt
-    ask_y_n
+    ask_yes_no
 );
 
 my $INPUT;
 sub prompt_returns { $INPUT = $_[1]; }
 
 my $Y_N;
-sub ask_y_n_returns { $Y_N = $_[1]; }
+sub ask_yes_no_returns { $Y_N = $_[1]; }
 
 my %CAPTURED;
 
@@ -61,9 +61,9 @@ $MOCK->mock(prompt => sub {
     return $INPUT;
 });
 
-$MOCK->mock(ask_y_n => sub {
+$MOCK->mock(ask_yes_no => sub {
     shift;
-    push @{ $CAPTURED{ask_y_n} } => [@_];
+    push @{ $CAPTURED{ask_yes_no} } => [@_];
     return $Y_N;
 });
 


### PR DESCRIPTION
The new version localizes the default value, and expects localized input from
the use, when a translation is available. Its second argument, when passed,
determines whether the default is affirmative (yes) or negative (no). The user
may input a substring of either answer, such as "y" for "Yes" or "j" for "Ja".
Translators therefore must be sure that the first char of each answer is
distinct, at least for now.

The ask_y_n() method is deprecated with a warning, and its use in Sqitch
itself replaced with calls to `ask_yes_no(). This change required changing the
way MockOutput handles mock prompts, as well.

Based on a suggestion by @tiguchi in #449.