### PR TITLE
Enforce scalar context when parsing sqlite version

### DIFF
--- a/lib/App/Sqitch/Engine/sqlite.pm
+++ b/lib/App/Sqitch/Engine/sqlite.pm
@@ -115,7 +115,7 @@ has _sqlite3 => (
 
         # Make sure we can use this version of SQLite.
         my @v = split /[.]/ => (
-            split / / => $self->sqitch->probe( $self->client, '-version' )
+            split / / => scalar $self->sqitch->capture( $self->client, '-version' )
         )[0];
         hurl sqlite => __x(
             'Sqitch requires SQLite 3.3.9 or later; {client} is {version}',


### PR DESCRIPTION
sqlite3 outputs an extra newline when v3.11.0 is installed
and ~/.sqliterc exists. This prevents us from parsing version.

Using capture and enforcing scalar context fixes the issue.
This commit addresses GitHub issue #460.