### PR TITLE
Don't call gecos on an undefined value.

### DIFF
--- a/Changes
+++ b/Changes
@@ -52,6 +52,12 @@ Revision history for Perl extension App::Sqitch
      - Fixed a Snowflake test failure when the current system username has a
        space or other character requiring URI escaping. Thanks to Ralph
        Andrade for the report (#463).
+     - Fixed an issue where a wayward newline in some versions of SQLite
+       prevented Sqitch from parsing the version. Thanks to Kivanc Yazan
+       for the report (#465) and the fix (#465)!
+     - Fixed an error when Sqitch was run on a system without a valid username,
+       such as some Docker environments. Thanks to Ferdinand Salis for the
+       report (#459)!
 
 0.9999 2019-02-01T15:29:40Z
      [Bug Fixes]

--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -83,7 +83,7 @@ has user_name => (
             || $ENV{ SQITCH_ORIG_FULLNAME }
         || do {
             my $sysname = $self->sysuser || hurl user => __(
-                    'Cannot find your name; run sqitch config --user user.name "YOUR NAME"'
+                'Cannot find your name; run sqitch config --user user.name "YOUR NAME"'
             );
             if (ISWIN) {
                 try { require Win32API::Net } || return $sysname;
@@ -93,10 +93,9 @@ has user_name => (
                 return Encode::decode( locale => $info->{fullName} );
             }
             require User::pwent;
-            my $name = (User::pwent::getpwnam($sysname)->gecos)[0]
-                || return $sysname;
+            my $name = User::pwent::getpwnam($sysname) || return $sysname;
             require Encode::Locale;
-            return Encode::decode( locale => $name );
+            return Encode::decode( locale => ($name->gecos)[0] );
         };
     }
 );


### PR DESCRIPTION
In some environments, `User::pwent::getpwnam()` returns an undefined value. So just return the system username in such cases, rather than die trying to call `gecos`. Thanks to Ferdinand Salis for the report. Resolves #459.