### PR TITLE
Add a sqitch check command that prints changes in plan for which script has changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         - export "PATH=/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:$PATH"
       install:
         # Last release doesn't depend on Test::MockObject::Extends
-        - cpanm --no-interactive --no-man-pages --notest --installdeps Test::MockObject::Extends
+        - cpanm --no-interactive --no-man-pages --notest Test::MockObject::Extends
         # Can't use dzil to make a dist on windows, so depend on the previous
         # release for dependencies.
         - cpanm --no-interactive --no-man-pages --notest --installdeps App::Sqitch

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
         - cinst -y strawberryperl
         - export "PATH=/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:$PATH"
       install:
+        # Last release doesn't depend on Test::MockObject::Extends
+        - cpanm --no-interactive --no-man-pages --notest --installdeps Test::MockObject::Extends
         # Can't use dzil to make a dist on windows, so depend on the previous
         # release for dependencies.
         - cpanm --no-interactive --no-man-pages --notest --installdeps App::Sqitch

--- a/dist.ini
+++ b/dist.ini
@@ -63,6 +63,7 @@ Template = 0
 Test::Pod = 1.41
 Test::Pod::Coverage = 1.08
 Test::Spelling = 0
+Test::MockObject::Extends = 1.20180705
 DBD::SQLite = 1.37
 DBD::Pg = 2.0
 DBD::mysql = 4.018

--- a/lib/App/Sqitch/Command/check.pm
+++ b/lib/App/Sqitch/Command/check.pm
@@ -164,10 +164,11 @@ The Sqitch command-line client.
 =head1 Author
 
 David E. Wheeler <david@justatheory.com>
+Matthieu Foucault <matthieu@button.is>
 
 =head1 License
 
-Copyright (c) 2012-2018 iovation Inc.
+Copyright (c) 2012-2019 iovation Inc., Button Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/App/Sqitch/Command/check.pm
+++ b/lib/App/Sqitch/Command/check.pm
@@ -9,7 +9,6 @@ use App::Sqitch::X qw(hurl);
 use Moo;
 use App::Sqitch::Types qw(Str Target Engine Change);
 use Try::Tiny;
-use Data::Dumper;
 use namespace::autoclean;
 
 extends 'App::Sqitch::Command';

--- a/lib/App/Sqitch/Command/check.pm
+++ b/lib/App/Sqitch/Command/check.pm
@@ -1,0 +1,209 @@
+package App::Sqitch::Command::check;
+
+use 5.010;
+use strict;
+use warnings;
+use utf8;
+use Locale::TextDomain qw(App-Sqitch);
+use App::Sqitch::X qw(hurl);
+use Moo;
+use App::Sqitch::Types qw(Str Target Engine Change);
+use Try::Tiny;
+use Data::Dumper;
+use namespace::autoclean;
+
+extends 'App::Sqitch::Command';
+with 'App::Sqitch::Role::ContextCommand';
+with 'App::Sqitch::Role::ConnectingCommand';
+
+# VERSION
+
+has target_name => (
+    is  => 'ro',
+    isa => Str,
+);
+
+has target => (
+    is      => 'rw',
+    isa     => Target,
+    handles => [qw(engine plan plan_file)],
+);
+
+has date_format => (
+    is      => 'ro',
+    lazy    => 1,
+    isa     => Str,
+    default => sub {
+        shift->sqitch->config->get( key => 'status.date_format' ) || 'iso'
+    }
+);
+
+has project => (
+    is      => 'ro',
+    isa     => Str,
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        try { $self->plan->project } catch {
+            # Just die on parse and I/O errors.
+            die $_ if try { $_->ident eq 'parse' || $_->ident eq 'io' };
+
+            # Try to extract a project name from the registry.
+            my $engine = $self->engine;
+            hurl status => __ 'Database not initialized for Sqitch'
+                unless $engine->initialized;
+            my @projs = $engine->registered_projects
+                or hurl status => __ 'No projects registered';
+            hurl status => __x(
+                'Use --project to select which project to query: {projects}',
+                projects => join __ ', ', @projs,
+            ) if @projs > 1;
+            return $projs[0];
+        };
+    },
+);
+
+sub options {
+    return qw(
+        project=s
+        target|t=s
+    );
+}
+
+sub execute {
+    my $self = shift;
+    my ($targets) = $self->parse_args(
+        target => $self->target_name,
+        args   => \@_,
+    );
+
+    # Warn on multiple targets.
+    my $target = shift @{ $targets };
+    $self->warn(__x(
+        'Too many targets specified; connecting to {target}',
+        target => $target->name,
+    )) if @{ $targets };
+
+    # Good to go.
+    $self->target($target);
+    my $engine = $target->engine;
+
+    # Where are we?
+    $self->comment( __x 'On database {db}', db => $engine->destination );
+
+    # Exit with status 1 on no state, probably not expected.
+    my $state = try {
+        $engine->current_state( $self->project )
+    } catch {
+        # Just die on parse and I/O errors.
+        die $_ if try { $_->ident eq 'parse' || $_->ident eq 'io' };
+
+        # Hrm. Maybe not initialized?
+        die $_ if $engine->initialized;
+        hurl status => __x(
+            'Database {db} has not been initialized for Sqitch',
+            db => $engine->registry_destination
+        );
+    };
+
+    my @deployed_changes = $engine->deployed_changes;
+
+    my %deployed_script_hashes;
+    foreach my $change ($engine->deployed_changes) {
+        $deployed_script_hashes{$change->{'id'}} = $change->{'script_hash'};
+    }
+
+    my $workdir_plan = $target->plan;
+    my @workdir_changes = $workdir_plan->changes;
+    foreach my $change (@workdir_changes) {
+        $self->comment(__x(
+            'Working directory script {script_file} is different from deployed script',
+            script_file => $change->deploy_file
+        )) if $change->script_hash ne $deployed_script_hashes{$change->id};
+    }
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 Name
+
+App::Sqitch::Command::check - Runs various checks and prints a report
+
+=head1 Synopsis
+
+  my $cmd = App::Sqitch::Command::check->new(%params);
+  $cmd->execute;
+
+=head1 Description
+
+If you want to know how to use the C<check> command, you probably want to be
+reading C<sqitch-check>. But if you really want to know how the C<check> command
+works, read on.
+
+=head1 Interface
+
+=head2 Attributes
+
+=head3 C<target_name>
+
+The name or URI of the database target as specified by the C<--target> option.
+
+=head3 C<target>
+
+An L<App::Sqitch::Target> object from which to perform the checks. Must be
+instantiated by C<execute()>.
+
+=head2 Instance Methods
+
+=head3 C<execute>
+
+  $check->execute;
+
+Executes the check command. The current state of the target database will be
+compared to the plan in order to show where things stand.
+
+=head1 See Also
+
+=over
+
+=item L<sqitch-check>
+
+Documentation for the C<check> command to the Sqitch command-line client.
+
+=item L<sqitch>
+
+The Sqitch command-line client.
+
+=back
+
+=head1 Author
+
+David E. Wheeler <david@justatheory.com>
+
+=head1 License
+
+Copyright (c) 2012-2018 iovation Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+=cut

--- a/lib/App/Sqitch/Command/check.pm
+++ b/lib/App/Sqitch/Command/check.pm
@@ -70,7 +70,7 @@ sub _collect_vars {
     return (
         %{ $cfg->get_section(section => 'core.variables') },
         %{ $cfg->get_section(section => 'deploy.variables') },
-        %{ $cfg->get_section(section => 'verify.variables') },
+        %{ $cfg->get_section(section => 'check.variables') },
         %{ $target->variables }, # includes engine
         %{ $self->variables },   # --set
     );

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1113,7 +1113,7 @@ sub _find_planned_deployed_divergence_idx {
 
     foreach my $change (@deployed_changes) {
         $i++;
-        return $i if $i >= $plan->count || $change->script_hash ne $plan->change_at($i + $from_idx)->script_hash;
+        return $i if $i + $from_idx >= $plan->count || $change->script_hash ne $plan->change_at($i + $from_idx)->script_hash;
     }
 
     return -1;
@@ -1122,7 +1122,7 @@ sub _find_planned_deployed_divergence_idx {
 sub planned_deployed_common_ancestor_id {
     my ( $self ) = @_;
     my @deployed_changes = $self->_load_changes( $self->deployed_changes );
-    my $divergent_idx = $self->_find_planned_deployed_divergence_idx(@deployed_changes);
+    my $divergent_idx = $self->_find_planned_deployed_divergence_idx(0, @deployed_changes);
 
     return $deployed_changes[-1]->id if $divergent_idx == -1;
     return undef if $divergent_idx == 0;

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1101,7 +1101,7 @@ sub _find_planned_deployed_divergence_idx {
 
     foreach my $change (@deployed_changes) {
         $i++;
-        return $i if $i >= $plan->count || $change->{'script_hash'} ne $plan->change_at($i)->script_hash;
+        return $i if $i >= $plan->count || $change->script_hash ne $plan->change_at($i)->script_hash;
     }
 
     return -1;
@@ -1157,6 +1157,8 @@ sub check {
         ),
         exitval => $num_failed,
     } if $num_failed;
+
+    $sqitch->emit(__ 'Check successful');
 
     return $self;
 }

--- a/lib/App/Sqitch/Role/DBIEngine.pm
+++ b/lib/App/Sqitch/Role/DBIEngine.pm
@@ -761,7 +761,7 @@ sub deployed_changes {
           LEFT JOIN tags t ON c.change_id = t.change_id
          WHERE c.project = ?
          GROUP BY c.change_id, c.change, c.project, c.note, c.planned_at,
-               c.planner_name, c.planner_email, c.committed_at
+               c.planner_name, c.planner_email, c.committed_at, c.script_hash
          ORDER BY c.committed_at ASC
     }, { Slice => {} }, $self->plan->project) };
 }

--- a/lib/sqitch-check-usage.pod
+++ b/lib/sqitch-check-usage.pod
@@ -1,0 +1,19 @@
+=head1 Name
+
+sqitch-check-usage - Sqitch check usage statement
+
+=head1 Usage
+
+  sqitch check [options] [<database>]
+
+=head1 Options
+
+    -t --target <target>       database to which to connect
+          --project <project>  project for which to perform the checks
+       --registry   <registry> registry schema or database
+       --db-client  <path>     path to the engine command-line client
+    -d --db-name    <name>     database name
+    -u --db-user    <user>     database user name
+    -h --db-host    <host>     database server host name
+    -p --db-port    <port>     database server port number
+    -f --plan-file  <file>     path to a deployment plan file

--- a/lib/sqitch-check.pod
+++ b/lib/sqitch-check.pod
@@ -1,6 +1,6 @@
 =head1 Name
 
-sqitch-check - Runs checks
+sqitch-check - Checks for divergences between planned and deployed changes.
 
 =head1 Synopsis
 

--- a/lib/sqitch-check.pod
+++ b/lib/sqitch-check.pod
@@ -1,0 +1,113 @@
+=head1 Name
+
+sqitch-check - Runs checks
+
+=head1 Synopsis
+
+  sqitch check [options] [<database>]
+
+=head1 Description
+
+Runs various checks on the state of the working directory and the database.
+The SHA1 hashes of the deployed scripts are compared the the ones from the
+working directory. Where discrepancies are found, messages are printed,
+indicating to the user that the working directory deploy scripts are different
+from the scripts that were used to deploy to the database.
+
+The C<< <database> >> parameter specifies the database to which to connect,
+and may also be specified as the C<--target> option. It can be target name,
+a URI, an engine name, or plan file path.
+
+=head1 Options
+
+=over
+
+=item C<-t>
+
+=item C<--target>
+
+The target database to which to connect. This option can be either a URI or
+the name of a target in the configuration.
+
+=item C<--project>
+
+Project for which to retrieve the status. Defaults to the status of the
+current project, if a plan can be found.
+
+=item C<--registry>
+
+  sqitch check --registry registry
+
+The name of the Sqitch registry schema or database in which sqitch stores its
+own data.
+
+=item C<--db-client>
+
+=item C<--client>
+
+  sqitch check --client /usr/local/pgsql/bin/psql
+
+Path to the command-line client for the database engine. Defaults to a client
+in the current path named appropriately for the database engine.
+
+=item C<-d>
+
+=item C<--db-name>
+
+  sqitch check --db-name widgets
+  sqitch check -d bricolage
+
+Name of the database. In general, L<targets|sqitch-target> and URIs are
+preferred, but this option can be used to override the database name in a
+target.
+
+=item C<-u>
+
+=item C<--db-user>
+
+=item C<--db-username>
+
+  sqitch check --db-username root
+  sqitch check --db-user postgres
+  sqitch check -u Mom
+
+User name to use when connecting to the database. Does not apply to all
+engines. In general, L<targets|sqitch-target> and URIs are preferred, but this
+option can be used to override the user name in a target.
+
+=item C<-h>
+
+=item C<--db-host>
+
+  sqitch check --db-host db.example.com
+  sqitch check -h appdb.example.net
+
+Host name to use when connecting to the database. Does not apply to all
+engines. In general, L<targets|sqitch-target> and URIs are preferred, but this
+option can be used to override the host name in a target.
+
+=item C<-p>
+
+=item C<--db-port>
+
+  sqitch check --db-port 7654
+  sqitch check -p 5431
+
+Port number to connect to. Does not apply to all engines. In general,
+L<targets|sqitch-target> and URIs are preferred, but this option can be used
+to override the port in a target.
+
+=item C<--plan-file>
+
+=item C<-f>
+
+  sqitch check --plan-file my.plan
+
+Path to the deployment plan file. Overrides target, engine, and core
+configuration values. Defaults to F<$top_dir/sqitch.plan>.
+
+=back
+
+=head1 Sqitch
+
+Part of the L<sqitch> suite.

--- a/lib/sqitch-rebase-usage.pod
+++ b/lib/sqitch-rebase-usage.pod
@@ -11,6 +11,7 @@ sqitch-rebase-usage - Sqitch rebase usage statement
     -t --target <target>              database to which to connect
        --onto --onto-change <change>  revert to change
        --upto --upto-change <change>  deploy to change
+       --revised                      revert to the common ancestor between the planned and deployed changes
        --mode <mode>                  deploy reversion mode (all, tag, change)
        --verify                       run verify scripts after each change
        --no-verify                    do not run verify scripts

--- a/lib/sqitch-rebase.pod
+++ b/lib/sqitch-rebase.pod
@@ -10,6 +10,8 @@ sqitch-rebase - Revert and redeploy database changes
   sqitch rebase [options] [<database>] <change>
   sqitch rebase [options] [<database>] <change> --upto-change <change>
   sqitch rebase [options] [<database>] <change> <change>
+  sqitch rebase [options] [<database>] --revised
+  sqitch rebase [options] [<database>] --revised --upto-change <change>
 
 =head1 Description
 
@@ -62,6 +64,13 @@ L<sqitchchanges> for the various ways in which changes can be specified.
 
 Specify the deployment change. Defaults to the last point in the plan. See
 L<sqitchchanges> for the various ways in which changes can be specified.
+
+=item C<--revised>
+
+Finds the change to revert onto based on the output of L<sqitch-check>. The
+change to be reverted onto will be the change that is before the first
+discrepancy between planned and deployed changes. This option checks the
+script hashes, and will re-deploy all changes whose deploy script was altered.
 
 =item C<--mode>
 

--- a/t/check.t
+++ b/t/check.t
@@ -1,0 +1,302 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use 5.010;
+use Test::More;
+use App::Sqitch;
+use App::Sqitch::Target;
+use Path::Class qw(dir file);
+use Test::MockModule;
+use Test::Exception;
+use Test::Warn;
+use Locale::TextDomain qw(App-Sqitch);
+use lib 't/lib';
+use MockOutput;
+use TestConfig;
+
+my $CLASS = 'App::Sqitch::Command::check';
+require_ok $CLASS or die;
+
+isa_ok $CLASS, 'App::Sqitch::Command';
+can_ok $CLASS, qw(
+    target
+    options
+    configure
+    new
+    from_change
+    to_change
+    variables
+    does
+);
+
+ok $CLASS->does("App::Sqitch::Role::$_"), "$CLASS does $_"
+    for qw(ContextCommand ConnectingCommand);
+
+is_deeply [$CLASS->options], [qw(
+    target|t=s
+    from-change|from=s
+    to-change|to=s
+    set|s=s%
+    plan-file|f=s
+    top-dir=s
+    registry=s
+    client|db-client=s
+    db-name|d=s
+    db-user|db-username|u=s
+    db-host|h=s
+    db-port|p=i
+)], 'Options should be correct';
+
+warning_is {
+    Getopt::Long::Configure(qw(bundling pass_through));
+    ok Getopt::Long::GetOptionsFromArray(
+        [], {}, App::Sqitch->_core_opts, $CLASS->options,
+    ), 'Should parse options';
+} undef, 'Options should not conflict with core options';
+
+my $config = TestConfig->new(
+    'core.engine'    => 'sqlite',
+    'core.plan_file' => file(qw(t sql sqitch.plan))->stringify,
+    'core.top_dir'   => dir(qw(t sql))->stringify,
+);
+my $sqitch = App::Sqitch->new(config => $config);
+
+##############################################################################
+# Test configure().
+is_deeply $CLASS->configure($config, {}), {
+    _params => [],
+    _cx     => [],
+}, 'Should have default configuration with no config or opts';
+
+is_deeply $CLASS->configure($config, {
+    from_change => 'foo',
+    to_change   => 'bar',
+    set  => { foo => 'bar' },
+}), {
+    from_change => 'foo',
+    to_change   => 'bar',
+    variables   => { foo => 'bar' },
+    _params     => [],
+    _cx         => [],
+}, 'Should have changes and variables from options';
+
+CONFIG: {
+    my $config = TestConfig->new(
+        'check.variables' => { foo => 'bar', hi => 21 },
+    );
+    is_deeply $CLASS->configure($config, {}), { _params => [], _cx => [] },
+        'Should have no config if no options';
+}
+
+##############################################################################
+# Test construction.
+isa_ok my $check = $CLASS->new(
+    sqitch   => $sqitch,
+    target => 'foo',
+), $CLASS, 'new status with target';
+is $check->target, 'foo', 'Should have target "foo"';
+
+isa_ok $check = $CLASS->new(sqitch => $sqitch), $CLASS;
+is $check->target, undef, 'Default target should be undef';
+is $check->from_change, undef, 'from_change should be undef';
+is $check->to_change, undef, 'to_change should be undef';
+
+##############################################################################
+# Test _collect_vars.
+my $target = App::Sqitch::Target->new(sqitch => $sqitch);
+is_deeply { $check->_collect_vars($target) }, {}, 'Should collect no variables';
+
+# Add core variables.
+$config->update('core.variables' => { prefix => 'widget', priv => 'SELECT' });
+$target = App::Sqitch::Target->new(sqitch => $sqitch);
+is_deeply { $check->_collect_vars($target) }, {
+    prefix => 'widget',
+    priv   => 'SELECT',
+}, 'Should collect core vars';
+
+# Add deploy variables.
+$config->update('deploy.variables' => { dance => 'salsa', priv => 'UPDATE' });
+$target = App::Sqitch::Target->new(sqitch => $sqitch);
+is_deeply { $check->_collect_vars($target) }, {
+    prefix => 'widget',
+    priv   => 'UPDATE',
+    dance  => 'salsa',
+}, 'Should override core vars with deploy vars';
+
+# Add check variables.
+$config->update('check.variables' => { dance => 'disco', lunch => 'pizza' });
+$target = App::Sqitch::Target->new(sqitch => $sqitch);
+is_deeply { $check->_collect_vars($target) }, {
+    prefix => 'widget',
+    priv   => 'UPDATE',
+    dance  => 'disco',
+    lunch  => 'pizza',
+}, 'Should override deploy vars with check vars';
+
+# Add engine variables.
+$config->update('engine.pg.variables' => { lunch => 'burrito', drink => 'whiskey' });
+my $uri = URI::db->new('db:pg:');
+$target = App::Sqitch::Target->new(sqitch => $sqitch, uri => $uri);
+is_deeply { $check->_collect_vars($target) }, {
+    prefix => 'widget',
+    priv   => 'UPDATE',
+    dance  => 'disco',
+    lunch  => 'burrito',
+    drink  => 'whiskey',
+}, 'Should override check vars with engine vars';
+
+# Add target variables.
+$config->update('target.foo.variables' => { drink => 'scotch', status => 'winning' });
+$target = App::Sqitch::Target->new(sqitch => $sqitch, name => 'foo', uri => $uri);
+is_deeply { $check->_collect_vars($target) }, {
+    prefix => 'widget',
+    priv   => 'UPDATE',
+    dance  => 'disco',
+    lunch  => 'burrito',
+    drink  => 'scotch',
+    status => 'winning',
+}, 'Should override engine vars with target vars';
+
+# Add --set variables.
+$check = $CLASS->new(
+    sqitch => $sqitch,
+    variables => { status => 'tired', herb => 'oregano' },
+);
+$target = App::Sqitch::Target->new(sqitch => $sqitch, name => 'foo', uri => $uri);
+is_deeply { $check->_collect_vars($target) }, {
+    prefix => 'widget',
+    priv   => 'UPDATE',
+    dance  => 'disco',
+    lunch  => 'burrito',
+    drink  => 'scotch',
+    status => 'tired',
+    herb   => 'oregano',
+}, 'Should override target vars with --set variables';
+
+$config->replace(
+    'core.engine'    => 'sqlite',
+    'core.plan_file' => file(qw(t sql sqitch.plan))->stringify,
+    'core.top_dir'   => dir(qw(t sql))->stringify,
+);
+$check = $CLASS->new( sqitch => $sqitch, no_prompt => 1);
+
+##############################################################################
+# Test execution.
+# Mock the engine interface.
+my $mock_engine = Test::MockModule->new('App::Sqitch::Engine::sqlite');
+my @args;
+$mock_engine->mock(check => sub { shift; @args = @_ });
+my @vars;
+$mock_engine->mock(set_variables => sub { shift; @vars = @_ });
+
+ok $check->execute, 'Execute with nothing.';
+is_deeply \@args, [undef, undef],
+    'Two undefs should be passed to the engine';
+is_deeply +MockOutput->get_warn, [], 'Should have no warnings';
+
+ok $check->execute('@alpha'), 'Execute from "@alpha"';
+is_deeply \@args, ['@alpha', undef],
+    '"@alpha" and undef should be passed to the engine';
+is_deeply +MockOutput->get_warn, [], 'Should again have no warnings';
+
+ok $check->execute('@alpha', '@beta'), 'Execute from "@alpha" to "@beta"';
+is_deeply \@args, ['@alpha', '@beta'],
+    '"@alpha" and "@beat" should be passed to the engine';
+is_deeply +MockOutput->get_warn, [], 'Should still have no warnings';
+
+isa_ok $check = $CLASS->new(
+    sqitch      => $sqitch,
+    from_change => 'foo',
+    to_change   => 'bar',
+    variables => { foo => 'bar', one => 1 },
+), $CLASS, 'Object with from, to, and variables';
+
+ok $check->execute, 'Execute again';
+is_deeply \@args, ['foo', 'bar'],
+    '"foo" and "bar" should be passed to the engine';
+is_deeply {@vars}, { foo => 'bar', one => 1 },
+    'Vars should have been passed through to the engine';
+is_deeply +MockOutput->get_warn, [], 'Still should have no warnings';
+
+# Pass and specify changes.
+ok $check->execute('roles', 'widgets'), 'Execute with command-line args';
+is_deeply \@args, ['foo', 'bar'],
+    '"foo" and "bar" should be passed to the engine';
+is_deeply {@vars}, { foo => 'bar', one => 1 },
+    'Vars should have been passed through to the engine';
+is_deeply +MockOutput->get_warn, [[__x(
+    'Too many changes specified; checking from "{from}" to "{to}"',
+    from => 'foo',
+    to   => 'bar',
+)]], 'Should have warning about which roles are used';
+
+# Pass a target.
+$target = 'db:pg:';
+my $mock_cmd = Test::MockModule->new(ref $check);
+my ($target_name_arg, $orig_meth);
+$mock_cmd->mock(parse_args => sub {
+    my $self = shift;
+    my %p = @_;
+    my @ret = $self->$orig_meth(@_);
+    $target_name_arg = $ret[0][0]->name;
+    $ret[0][0] = $self->default_target;
+    return @ret;
+});
+$orig_meth = $mock_cmd->original('parse_args');
+
+ok $check->execute($target), 'Execute with target arg';
+is $target_name_arg, $target, 'The target should have been passed to the engine';
+is_deeply \@args, ['foo', 'bar'],
+    '"foo" and "bar" should be passed to the engine';
+is_deeply {@vars}, { foo => 'bar', one => 1 },
+    'Vars should have been passed through to the engine';
+is_deeply +MockOutput->get_warn, [], 'Should once again have no warnings';
+
+# Pass a --target option.
+isa_ok $check = $CLASS->new(
+    sqitch => $sqitch,
+    target => $target,
+), $CLASS, 'Object with target';
+$target_name_arg = undef;
+@vars = ();
+ok $check->execute, 'Execute with no args';
+is $target_name_arg, $target, 'The target option should have been passed to the engine';
+is_deeply \@args, [undef, undef], 'Undefs should be passed to the engine';
+is_deeply {@vars}, {}, 'No vars should have been passed through to the engine';
+is_deeply +MockOutput->get_warn, [], 'Should once again have no warnings';
+
+# Pass a target, get a warning.
+ok $check->execute('db:sqlite:', 'roles', 'widgets'),
+    'Execute with two targegs and two changes';
+is $target_name_arg, $target, 'The target option should have been passed to the engine';
+is_deeply \@args, ['roles', 'widgets'],
+    'The two changes should be passed to the engine';
+is_deeply {@vars}, {}, 'No vars should have been passed through to the engine';
+is_deeply +MockOutput->get_warn, [[__x(
+    'Too many targets specified; connecting to {target}',
+    target => $check->default_target->name,
+)]], 'Should have warning about too many targets';
+
+# Make sure we get an exception for unknown args.
+throws_ok { $check->execute(qw(greg)) } 'App::Sqitch::X',
+    'Should get an exception for unknown arg';
+is $@->ident, 'check', 'Unknow arg ident should be "check"';
+is $@->message, __nx(
+    'Unknown argument "{arg}"',
+    'Unknown arguments: {arg}',
+    1,
+    arg => 'greg',
+), 'Should get an exeption for two unknown arg';
+
+throws_ok { $check->execute(qw(greg jon)) } 'App::Sqitch::X',
+    'Should get an exception for unknown args';
+is $@->ident, 'check', 'Unknow args ident should be "check"';
+is $@->message, __nx(
+    'Unknown argument "{arg}"',
+    'Unknown arguments: {arg}',
+    2,
+    arg => 'greg, jon',
+), 'Should get an exeption for two unknown args';
+
+done_testing;

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -799,6 +799,7 @@ sub run {
             planner_name  => $change->planner_name,
             planner_email => $change->planner_email,
             tags          => ['@alpha'],
+            script_hash   => $change->script_hash,
         };
         my $change2_hash = {
             id            => $change2->id,
@@ -809,6 +810,7 @@ sub run {
             planner_name  => $change2->planner_name,
             planner_email => $change2->planner_email,
             tags          => [],
+            script_hash   => $change2->script_hash,
         };
 
         is_deeply [$engine->deployed_changes], [$change_hash, $change2_hash],

--- a/t/rebase.t
+++ b/t/rebase.t
@@ -42,6 +42,7 @@ ok $CLASS->does("App::Sqitch::Role::$_"), "$CLASS does $_"
 is_deeply [$CLASS->options], [qw(
     onto-change|onto=s
     upto-change|upto=s
+    revised!
     plan-file|f=s
     top-dir=s
     registry=s


### PR DESCRIPTION
Re #475 

I'm thinking about adding a `--redeploy` option that would revert to the appropriate change and deploy the plan again, so that the database has deployed changes matching the working directoy.

It's my first time writing in Perl, so let me know if I am missing some language idioms, or if there are some lines in there that look horribly wrong.

It's still a draft. I haven't written any test yet, and I am sure I am missing a lot of edge cases.
Happy to receive feedback either way :)