### PR TITLE
Only add password to the mysql command when no .my.cnf is used

### DIFF
--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -171,7 +171,8 @@ has _mysql => (
 
         # Special-case --password, which requires = before the value. O_o
         if (my $pw = $self->password) {
-            push @ret, "--password=$pw";
+            push @ret, "--password=$pw"
+               unless $self->_mycnf->{password};
         }
 
         # Options to keep things quiet.

--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -171,7 +171,7 @@ has _mysql => (
 
         # Special-case --password, which requires = before the value. O_o
         if (my $pw = $self->password) {
-            my $cfgpw = $self->_mycnf->{password} || '';
+            my $cfgpwd = $self->_mycnf->{password} || '';
             push @ret, "--password=$pw" if $pw ne $cfgpwd;
         }
 

--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -171,8 +171,8 @@ has _mysql => (
 
         # Special-case --password, which requires = before the value. O_o
         if (my $pw = $self->password) {
-            push @ret, "--password=$pw"
-               unless $self->_mycnf->{password};
+            my $cfgpw = $self->_mycnf->{password} || '';
+            push @ret, "--password=$pw" if $pw ne $cfgpwd;
         }
 
         # Options to keep things quiet.


### PR DESCRIPTION
Later versions of MySQL generate the following warning when using the --password command-line option.

```
mysql: [Warning] Using a password on the command line interface can be insecure.
```

Very annoying. This change avoids it when using a .my.cnf file.

