### PR TITLE
Update IPC::System::Simple check on Win32.

### DIFF
--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -332,7 +332,7 @@ sub run {
         ( my $msg = shift ) =~ s/\s+at\s+.+/\n/ms;
         die $msg;
     };
-    if (ISWIN && IPC::System::Simple->VERSION <= 1.25) {
+    if (ISWIN && IPC::System::Simple->VERSION <= 1.26) {
         runx ( shift, $self->quote_shell(@_) );
         return $self;
     }

--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -332,7 +332,7 @@ sub run {
         ( my $msg = shift ) =~ s/\s+at\s+.+/\n/ms;
         die $msg;
     };
-    if (ISWIN && IPC::System::Simple->VERSION <= 1.26) {
+    if (ISWIN && IPC::System::Simple->VERSION < 1.30) {
         runx ( shift, $self->quote_shell(@_) );
         return $self;
     }

--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -332,7 +332,7 @@ sub run {
         ( my $msg = shift ) =~ s/\s+at\s+.+/\n/ms;
         die $msg;
     };
-    if (ISWIN && IPC::System::Simple->VERSION < 1.30) {
+    if (ISWIN && IPC::System::Simple->VERSION < 1.28) {
         runx ( shift, $self->quote_shell(@_) );
         return $self;
     }


### PR DESCRIPTION
Turns out 1.26 was released in January without the fix for Win32. Recently, however, pjf/ipc-system-simple#29 was merged and 1.28 released, fixing the Win32 issue. So update the workaround here to operate on 1.27 and earlier. Resolves #478.