### PR TITLE
Fix sqlite3 inplace changes tutorial

### DIFF
--- a/lib/sqitchtutorial-sqlite.pod
+++ b/lib/sqitchtutorial-sqlite.pod
@@ -1153,7 +1153,7 @@ Here's the diff:
      FROM userflips
     WHERE 0;
  
-And finally, modify F<revert/userflips@v1.0.0-dev2.sql> to drop the view
+And finally, modify F<revert/userflips.sql> to drop the view
 before creating it:
 
   @@ -4,6 +4,7 @@


### PR DESCRIPTION
When making an inplace change to the userflips view I think we should modify the
`revert/userflips.sql` file, not the `revert/userflips@v1.0.0-dev2.sql`
that is generated for us by sqitch.