### PR TITLE
Add destination locking to pgsql and mysql

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,14 @@ Revision history for Perl extension App::Sqitch
      - Fixed the error message when attempting to deploy a change that has
        already been deployed to display the name of the change, rather than a
        memory address. Thanks to Neil Mayhew for the report (#579).
+     - Added destination locking, currently implemented for PostgresQL and
+       MySQL. On starting a deploy or revert, Sqitch attempts to "lock the
+       destination" using advisory locks, to ensure that only one instance of
+       Sqitch makes changes to the database at any one time. This complements
+       the existing locking, which applies as each change is deployed or
+       reverted, as that pattern led to failures when multiple instances of
+       Sqitch were working at once. Thanks to Neil Mayhew for the report
+       (#579).
 
 1.1.0  2020-05-17T16:20:07Z
      - Fixed Perl Pod errors, thanks to a pull request from Mohammad S Anwar

--- a/dist/sqitch.spec
+++ b/dist/sqitch.spec
@@ -126,6 +126,7 @@ Requires:       perl(String::ShellQuote)
 Requires:       perl(Sub::Exporter)
 Requires:       perl(Sub::Exporter::Util)
 Requires:       perl(Sys::Hostname)
+Requires:       perl(Sys::SigAction)
 Requires:       perl(Template::Tiny) >= 0.11
 Requires:       perl(Term::ANSIColor) >= 2.02
 Requires:       perl(Throwable) >= 0.200009

--- a/lib/App/Sqitch/Command/checkout.pm
+++ b/lib/App/Sqitch/Command/checkout.pm
@@ -58,6 +58,7 @@ sub execute {
     $engine->no_prompt( $self->no_prompt );
     $engine->prompt_accept( $self->prompt_accept );
     $engine->log_only( $self->log_only );
+    $engine->lock_timeout( $self->lock_timeout );
 
     # What branch are we on?
     my $current_branch = $sqitch->probe($git, qw(rev-parse --abbrev-ref HEAD));

--- a/lib/App/Sqitch/Command/checkout.pm
+++ b/lib/App/Sqitch/Command/checkout.pm
@@ -58,7 +58,6 @@ sub execute {
     $engine->no_prompt( $self->no_prompt );
     $engine->prompt_accept( $self->prompt_accept );
     $engine->log_only( $self->log_only );
-    $engine->lock_timeout( $self->lock_timeout );
 
     # What branch are we on?
     my $current_branch = $sqitch->probe($git, qw(rev-parse --abbrev-ref HEAD));

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -10,7 +10,7 @@ use Path::Class qw(file);
 use App::Sqitch::X qw(hurl);
 use List::Util qw(first max);
 use URI::db 0.19;
-use App::Sqitch::Types qw(Str Int Sqitch Plan Bool HashRef URI Maybe Target);
+use App::Sqitch::Types qw(Str Int Num Sqitch Plan Bool HashRef URI Maybe Target);
 use namespace::autoclean;
 use constant registry_release => '1.1';
 
@@ -118,8 +118,8 @@ has _variables => (
 
 has lock_timeout => (
     is      => 'rw',
-    isa     => Int,
-    default => 600,
+    isa     => Num,
+    default => 60,
 );
 
 has _locked => (
@@ -1575,6 +1575,11 @@ list.
 The username to use to connect to the database, for engines that require
 authentication. The username is looked up in the following places, returning
 the first to have a value:
+
+=head3 C<lock_timeout>
+
+Numeber of seconds to C<lock_destination()> to wait to acquire a lock before
+timint out. Defaults to 60.
 
 =over
 

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1039,9 +1039,9 @@ sub lock_destination {
 
     # Try waiting for the lock.
     require Sys::SigAction;
-    return $self->_locked(1) unless Sys::SigAction::timeout_call(
-        $wait, sub { $self->wait_lock }
-    );
+    return $self->_locked(1) unless Sys::SigAction::timeout_call($wait, sub {
+        $self->wait_lock
+    });
 
     # Timed out, so bail.
     hurl engine => __x(

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1578,8 +1578,8 @@ the first to have a value:
 
 =head3 C<lock_timeout>
 
-Numeber of seconds to C<lock_destination()> to wait to acquire a lock before
-timint out. Defaults to 60.
+Number of seconds to C<lock_destination()> to wait to acquire a lock before
+timing out. Defaults to 60.
 
 =over
 

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -116,6 +116,18 @@ has _variables => (
     default => sub { {} },
 );
 
+has lock_timeout => (
+    is      => 'rw',
+    isa     => Int,
+    default => 600,
+);
+
+has _locked => (
+    is      => 'rw',
+    isa     => Bool,
+    default => 0,
+);
+
 sub variables       { %{ shift->_variables }       }
 sub set_variables   {    shift->_variables({ @_ }) }
 sub clear_variables { %{ shift->_variables } = ()  }
@@ -173,7 +185,7 @@ sub use_driver {
 
 sub deploy {
     my ( $self, $to, $mode ) = @_;
-    $self->lock_session;
+    $self->lock_destination;
     my $sqitch   = $self->sqitch;
     my $plan     = $self->_sync_plan;
     my $to_index = $plan->count - 1;
@@ -255,7 +267,7 @@ sub deploy {
 
 sub revert {
     my ( $self, $to ) = @_;
-    $self->lock_session;
+    $self->lock_destination;
     $self->_check_registry;
     my $sqitch = $self->sqitch;
     my $plan   = $self->plan;
@@ -1010,7 +1022,41 @@ sub revert_change {
     };
 }
 
-sub lock_session { shift }
+sub lock_destination {
+    my $self = shift;
+
+    # Try to acquire the lock without waiting.
+    return $self if $self->_locked;
+    return $self->_locked(1) if $self->try_lock;
+
+    # Lock not acquired. Tell the user what's happening.
+    my $wait = $self->lock_timeout;
+    $self->sqitch->info(__x(
+        'Blocked by another instance of Sqitch working on {dest}; waiting {secs} seconds...',
+        dest => $self->destination,
+        secs => $wait,
+    ));
+
+    # Try waiting for the lock.
+    require Sys::SigAction;
+    return $self->_locked(1) unless Sys::SigAction::timeout_call(
+        $wait, sub { $self->wait_lock }
+    );
+
+    # Timed out, so bail.
+    hurl engine => __x(
+        'Timed out waiting {secs} seconds for another instance of Sqitch to finish work on {dest}',
+        dest => $self->destination,
+        secs => $wait,
+    );
+}
+
+sub try_lock { 1 }
+sub wait_lock {
+    my $class = ref $_[0] || $_[0];
+    hurl "$class has not implemented wait_lock()";
+}
+
 sub begin_work  { shift }
 sub finish_work { shift }
 sub rollback_work { shift }
@@ -1917,24 +1963,44 @@ does.
 Upgrades the target's registry, if it needs upgrading. Used by the
 L<C<upgrade>|App::Sqitch::Command::upgrade> command.
 
+=head3 C<lock_destination>
+
+  $engine->lock_destination;
+
+This method is called before deploying or reverting changes. It attempts
+to acquire a lock in the destination database to ensure that no other
+instances of Sqitch can act on the database at the same time. If it fails
+to acquire the lock, it emits a message to that effect, then tries again
+and waits. If it acquires the lock, it continues its work. If the attempt
+times out after C<lock_timeout> seconds, it exits with an error.
+
+The default implementation is effectively a no-op; consult the documentation
+for specific engines to determine whether they have implemented support for
+destination locking (by overriding C<try_lock()> and C<wait_lock()>).
+
 =head2 Abstract Instance Methods
 
 These methods must be overridden in subclasses.
 
-=head3 C<lock_session>
+=head3 C<try_lock>
 
-  $engine->lock_session;
+  $engine->try_lock;
 
-This method is called before deploying or reverting changes. It should create
-a lock to prevent any other process from making changes to the registry for
-the duration of the deployment or reversion. It should also be idempotent,
-since commands such as C<rebase> and C<checkout> will both deploy and revert,
-causing this method to be called multiple times. The lock should not be freed
-until the application exits.
+This method is called by C<lock_destination>, and this default implementation
+simply returns true. May be overridden in subclasses to acquire a database
+lock that would prevent any other instance of Sqitch from making changes at
+the same time. If it cannot acquire the lock, it should immediately return
+false without waiting.
 
-In the event the lock cannot be acquired, an exception must be thrown to tell
-the user that multiple instances of Sqitch may be attempting to work at the
-same time.
+=head3 C<wait_lock>
+
+  $engine->wait_lock;
+
+This method is called by C<lock_destination> when C<try_lock> returns false.
+It must be implemented if C<try_lock> is overridden; otherwise it throws
+an error when C<try_lock> returns false. It should attempt to acquire the
+same lock as C<try_lock>, but wait indefinitely for it. No need for a timeout;
+C<lock_destination> will time out after C<lock_timeout> seconds.
 
 =head3 C<begin_work>
 
@@ -1942,9 +2008,9 @@ same time.
 
 This method is called just before a change is deployed or reverted. It should
 create a lock to prevent any other processes from making changes to the
-database, to be freed in C<finish_work> or C<rollback_work>. Unlike C<lock_session>,
-this method generally starts a transaction for the duration of the deployment
-or reversion of a single change.
+database, to be freed in C<finish_work> or C<rollback_work>. Unlike
+C<lock_destination>, this method generally starts a transaction for the
+duration of the deployment or reversion of a single change.
 
 =head3 C<finish_work>
 

--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -303,6 +303,18 @@ sub begin_work {
     return $self;
 }
 
+sub lock_session {
+    my $self = shift;
+    # Try to create a lock and raise an error if we can't.
+    $self->dbh->selectcol_arrayref(
+        q{SELECT get_lock('sqitch working', 0)}
+    )->[0] or hurl engine => __x(
+        'Cannot lock registry; another instance of Sqitch is working on {destination}',
+        destination => $self->destination,
+    );
+    return $self;
+}
+
 # Override to unlock the tables, otherwise future transactions on this
 # connection can fail.
 sub finish_work {

--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -263,14 +263,14 @@ sub begin_work {
     return $self;
 }
 
-sub _try_lock {
+sub try_lock {
     # Try to get a lock but don't wait.
     shift->dbh->selectcol_arrayref(
         'SELECT pg_try_advisory_lock(75474063)'
     )->[0]
 }
 
-sub _wait_lock {
+sub wait_lock {
     # Wait indefinitely for the lock.
     shift->dbh->do('SELECT pg_advisory_lock(75474063)');
 }

--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -263,6 +263,18 @@ sub begin_work {
     return $self;
 }
 
+sub lock_session {
+    my $self = shift;
+    # Try to create a session lock and raise an error if we can't.
+    $self->dbh->selectcol_arrayref(
+        'SELECT pg_try_advisory_lock(75474063)'
+    )->[0] or hurl engine => __x(
+        'Cannot lock registry; another instance of Sqitch is working on {destination}',
+        destination => $self->destination,
+    );
+    return $self;
+}
+
 sub run_file {
     my ($self, $file) = @_;
     $self->_run('--file' => $file);

--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -263,16 +263,16 @@ sub begin_work {
     return $self;
 }
 
-sub lock_session {
-    my $self = shift;
-    # Try to create a session lock and raise an error if we can't.
-    $self->dbh->selectcol_arrayref(
+sub _try_lock {
+    # Try to get a lock but don't wait.
+    shift->dbh->selectcol_arrayref(
         'SELECT pg_try_advisory_lock(75474063)'
-    )->[0] or hurl engine => __x(
-        'Cannot lock registry; another instance of Sqitch is working on {destination}',
-        destination => $self->destination,
-    );
-    return $self;
+    )->[0]
+}
+
+sub _wait_lock {
+    # Wait indefinitely for the lock.
+    shift->dbh->do('SELECT pg_advisory_lock(75474063)');
 }
 
 sub run_file {

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -56,6 +56,9 @@ sub run {
         change_offset_from_id
         change_id_offset_from_id
         load_change
+        lock_destination
+        try_lock
+        wait_lock
     );
 
     subtest 'live database' => sub {

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -10,6 +10,7 @@ use Time::HiRes qw(sleep);
 use Path::Class 0.33 qw(file dir);
 use Digest::SHA qw(sha1_hex);
 use Locale::TextDomain qw(App-Sqitch);
+use Sys::SigAction qw(timeout_call);
 use File::Temp 'tempdir';
 
 # Just die on warnings.
@@ -1714,6 +1715,51 @@ sub run {
         while (my $row = $sth->fetch) {
             is $row->[1], $row->[0],
                 'Change ID and script hash should be ' . substr $row->[0], 0, 6;
+        }
+
+        ######################################################################
+        # Test try_lock() and wait_lock().
+        if (my $sql = $p{lock_sql}) {
+            ok !$engine->dbh->selectcol_arrayref($sql->{is_locked})->[0],
+                'Should not be locked';
+            ok $engine->try_lock, 'Try lock';
+            ok $engine->dbh->selectcol_arrayref($sql->{is_locked})->[0],
+                'Should be locked';
+            ok $engine->wait_lock, 'Should not have to wait for lock';
+
+            # Make a second connection to the database.
+            my $dbh = DBI->connect($engine->uri->dbi_dsn, $engine->username, $engine->password, {
+                PrintError        => 0,
+                RaiseError        => 1,
+                AutoCommit        => 1,
+            });
+            ok !$dbh->selectcol_arrayref($sql->{try_lock})->[0],
+                'Should fail to get same lock in second connection';
+
+            lives_ok { $engine->dbh->do($sql->{free_lock}) } 'Free the lock';
+            ok !$engine->dbh->selectcol_arrayref($sql->{is_locked})->[0],
+                'Should not be locked';
+            ok $dbh->selectcol_arrayref($sql->{try_lock})->[0],
+                'Should now get the lock in second connection';
+            ok $engine->dbh->selectcol_arrayref($sql->{is_locked})->[0],
+                'Should be locked';
+            ok !$engine->try_lock, 'Try lock should now return false';
+
+            # Make sure that wait_lock waits.
+            ok timeout_call(0.1, sub { $engine->wait_lock }),
+                'Should have to wait for lock';
+            lives_ok { $dbh->do($sql->{free_lock}) } 'Free the second lock';
+            # Work to free all the locks in case previous waits actually finished.
+            my $wait = 1;
+            while ($wait) {
+                $wait = $engine->dbh->selectcol_arrayref($sql->{free_lock})->[0];
+            }
+
+            # Now wait lock should acquire the lock.
+            ok $engine->wait_lock, 'Should no longer wait for lock';
+            ok $engine->dbh->selectcol_arrayref($sql->{is_locked})->[0],
+                'Should be locked';
+            lives_ok { $dbh->do($sql->{free_lock}) } 'Free the lock one last time';
         }
 
         ######################################################################

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 # To test against a live MySQL database, you must set the MYSQL_URI environment variable.
-# this is a stanard URI::db URI, and should look something like this:
+# this is a standard URI::db URI, and should look something like this:
 #
 #     export MYSQL_URI=db:mysql://root:password@localhost:3306/information_schema
 #
@@ -492,14 +492,14 @@ DBIEngineTest->run(
         my $dbh = shift;
         # Check the session configuration.
         for my $spec (
-            [character_set_client   => 'utf8'],
-            [character_set_server   => 'utf8'],
-            ($dbh->{mysql_serverversion} < 50500 ? () : ([default_storage_engine => 'InnoDB'])),
-            [time_zone              => '+00:00'],
-            [group_concat_max_len   => 32768],
+            [character_set_client   => qr/^utf8/],
+            [character_set_server   => qr/^utf8/],
+            ($dbh->{mysql_serverversion} < 50500 ? () : ([default_storage_engine => qr/^InnoDB$/])),
+            [time_zone              => qr/^\+00:00$/],
+            [group_concat_max_len   => qr/^32768$/],
         ) {
-            is $dbh->selectcol_arrayref('SELECT @@SESSION.' . $spec->[0])->[0],
-                $spec->[1], "Setting $spec->[0] should be set to $spec->[1]";
+            like $dbh->selectcol_arrayref('SELECT @@SESSION.' . $spec->[0])->[0],
+                $spec->[1], "Setting $spec->[0] should match $spec->[1]";
         }
 
         # Special-case sql_mode.
@@ -515,6 +515,11 @@ DBIEngineTest->run(
         )) {
             like $sql_mode, qr/\b\Q$mode\E\b/i, "sql_mode should include $mode";
         }
+    },
+    lock_sql => {
+        is_locked => q{SELECT is_used_lock('sqitch working')},
+        try_lock  => q{SELECT get_lock('sqitch working', 0)},
+        free_lock => 'SELECT release_all_locks()',
     },
 );
 

--- a/t/pg.t
+++ b/t/pg.t
@@ -317,6 +317,11 @@ DBIEngineTest->run(
         is $dbh->selectcol_arrayref('SELECT current_schema')->[0],
             '__sqitchtest', 'The Sqitch schema should be the current schema';
     },
+    lock_sql => {
+        is_locked => q{SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND objid = 75474063 AND objsubid = 1},
+        try_lock  => 'SELECT pg_try_advisory_lock(75474063)',
+        free_lock => 'SELECT pg_advisory_unlock_all()',
+    },
 );
 
 done_testing;

--- a/xt/release/pod-spelling.t
+++ b/xt/release/pod-spelling.t
@@ -118,3 +118,4 @@ Blockchain
 Merkle
 rebases
 Matthieu
+OpenID


### PR DESCRIPTION
This PR takes on the issue raised in #579 by adding support for advisory locking to the engine, with implementations for MySQL and Postgres. It relies on engines to implement two methods:

* `try_lock`, which will try to create an exclusive lock and immediately return on success or failure
* `wait_lock`, which will try to create an exclusive lock and wait indefinitely to acquire it

Both methods should create exactly the same lock, statically defined by the engines, so that no other instance of Sqitch can be making changes to the database at the same time. The new `lock_destination` method is called at the start of both `deploy` and `revert`. It calls `try_lock`, and if it succeeds, returns, but if it doesn't, it emits a message about its inability to get the lock, then calls `wait_lock` to wait for it. The new `lock_timeout` attribute controls the wait timeout (60s by default), and `lock_destination` handles the timeout by raising an error, which will cause Sqitch to exit.

New tests in `t/engine.t` cover the behavior of `lock_destination`, while new testing and configuration tests engine-specific implementations in `t/lib/DBIEngineTest`.

I'd appreciate a close reading of this PR, as there are a few things we should consider. In particular:

* Do we really want this enabled by default? Or should we add configuration/options to turn it on? Or perhaps configuration/options to turn it off?
* Is using Sys::SigAction sufficient to handle the timeout, including on non-Unix hosts (Windows)? Or is it likely to run into issues/conflicts with the database? Might some database locking carry on even when the timeout kicks in? (I suspect it does, since I had to add code to repeatedly clear locks to the tests, though in practice it should not be an issue, since Sqitch will exit, not hang around holding onto locks unnecessarily. But MySQL in particular is weird).

I expect to add the necessary configuration/options in a followup PR. Thank you!

Closing #579.