### PR TITLE
Skip OS tests on tag.

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -3,7 +3,10 @@
 # the latest versions of Ubuntu, macOS, and Windows. Think of it as a quick
 # check for working branches.
 name: 💿 OS
-on: [push, pull_request]
+on:
+  push:
+    branches: ['*']
+  pull_request:
 jobs:
   OS:
     strategy:


### PR DESCRIPTION
All the workflows aside from release.yml have a branch spec now, so none will run when pushing a tag.