### PR TITLE
Fix a Firebird test and upgrade issues

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl extension App::Sqitch
 
 1.2.2
 
+     - Fixed an issue when testing Firebird on a host with Firebird installed
+       but no `isql`, and when using a local Firebird (e.g., the Engine12
+       provider), which allows only one connection at a time. Thanks to Slaven
+       Rezić for the the reproducible configuration (#597).
+
 1.2.1  2021-12-05T19:59:45Z
      - Updated all the live engine tests, aside from Oracle, to test with
        unique registry names, so as to avoid conflicts when multiple


### PR DESCRIPTION
Commit bdc2b0caf conflated the target database with the registry database. So give the registry a more distinctive name, restore the separate name for the database we create for testing (when none exists already), and skip cleanup for any database files that don't exist (because no live tests were run).

Also, disconnect from a local Firebird connection on upgrade. With a direct connection (with no host name), there can be only one connection do the database at a time. This is a problem for upgrades, where we already have a DBI
connection and then use `isql` to perform the upgrade. So disconnect DBI from the database before performing an upgrade, and add a Moo method to clear the `dbh` attribute, which will allow it to reconnect the next time it's called.

Figured out by using the Docker image specified in #597 and installing the `firebird3.0-utils` package.

Fixes #597.