### PR TITLE
Add support for YugabyteDB

### DIFF
--- a/.github/workflows/yugabyte.yml
+++ b/.github/workflows/yugabyte.yml
@@ -1,20 +1,29 @@
 # This workflow tests Sqitch's PostgreSQL engine on all supported versions of
-# Postgres. It runs for pushes and pull requests on the `main`, `develop`,
+# YugabyteDB. It runs for pushes and pull requests on the `main`, `develop`,
 # `**postgres**`, `**yugabyte**`, and `**engine**` branches.
-name: 🐘 Postgres
+name: 💫 YugabyteDB
 on:
   push:
     branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
   pull_request:
     branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
 jobs:
-  Postgres:
+  Yugabyte:
     strategy:
       matrix:
-        pg: [14, 13, 12, 11, 10, 9.6, 9.5, 9.4, 9.3] #, 9.2, 9.1, 9.0, 8.4] https://github.com/bucardo/dbdpg/issues/84
-    name: 🐘 Postgres ${{ matrix.pg }}
+        include:
+          - { version: '2.13', tag: 2.13.2.0-b135 }
+          - { version: '2.12', tag: 2.12.5.0-b24  }
+          - { version: '2.8',  tag: 2.8.6.0-b12   }
+          - { version: '2.6',  tag: 2.6.18.0-b3   }
+    name: 💫 YugabyteDB ${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
+      - name: Setup YugabyteDB cluster
+        id: yugabyte
+        uses: yugabyte/yugabyte-db-action@master
+        with:
+          yb_image_tag: "${{ matrix.tag }}"
       - uses: actions/checkout@v2
       - name: Setup Perl
         id: perl
@@ -26,18 +35,10 @@ jobs:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
       - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-        # DBD::Pg always build against the Debian packaged client, alas, so go
-        # ahead and let it be cached. If can figure out how to install the
-        # version-specific client (https://github.com/bucardo/dbdpg/issues/84),
-        # use cpm install --global to install DBD::Pg for a version-specific
-        # build each time.
       - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::Pg
-      - name: Install Postgres
-        env: { PERL5LIB: "${{ github.workspace }}/local/lib/perl5" }
-        run: .github/ubuntu/pg.sh ${{ matrix.pg }}
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"
           LIVE_PG_REQUIRED: true
-          SQITCH_TEST_PG_URI: db:pg://postgres@/postgres
+          SQITCH_TEST_PG_URI: db:pg://yugabyte@localhost:${{ steps.yugabyte.outputs.ysql_port }}/
         run: prove -lvr t/pg.t

--- a/Changes
+++ b/Changes
@@ -1,11 +1,13 @@
 Revision history for Perl extension App::Sqitch
 
 1.2.2
-
      - Fixed an issue when testing Firebird on a host with Firebird installed
        but no `isql`, and when using a local Firebird (e.g., the Engine12
        provider), which allows only one connection at a time. Thanks to Slaven
        Rezić for the the reproducible configuration (#597).
+     - Tweaked the Postgres engine to support Yugabyte. The only unsupported
+       features are explicit locks, so users need to manually ensure that only
+       one instance of Sqitch is updating the cluster at a time.
 
 1.2.1  2021-12-05T19:59:45Z
      - Updated all the live engine tests, aside from Oracle, to test with

--- a/README.md
+++ b/README.md
@@ -7,10 +7,20 @@ App/Sqitch version v1.2.2-dev
 | [![Docker]][🐳]   | [![Perl]][🧅]     | [![Firebird]][🔥] | [![Snowflake]][❄️] |
 | [![Homebrew]][🍺] | [![Coverage]][📈] | [![MySQL]][🐬]    | [![SQLite]][💡]   |
 | [![Debian]][🍥]   |                   | [![Postgres]][🐘] | [![Vertica]][🔺]  |
+|                   |                   | [![Yugabyte]][🚀] |                  |
 
-[Sqitch] is a database change management application. It currently supports
-PostgreSQL 8.4+, SQLite 3.7.11+, MySQL 5.0+, Oracle 10g+, Firebird 2.0+, Vertica
-6.0+, Exasol 6.0+ and Snowflake.
+[Sqitch] is a database change management application. It currently supports:
+
+*   [PostgreSQL] 8.4+
+*   [YugabyteDB] 2.6+
+*   [SQLite][lite] 3.7.11+
+*   [MySQL][my] 5.0+
+*   [MariaDB] 10.0+
+*   [Oracle][orcl] 10g+,
+*   [Firebird][bird] 2.0+
+*   [Vertica][vert] 6.0+
+*   [Exasol][exa] 6.0+
+*   [Snowflake][flake]
 
 What makes it different from your typical migration approaches? A few things:
 
@@ -24,7 +34,7 @@ What makes it different from your typical migration approaches? A few things:
 
     Changes are implemented as scripts native to your selected database engine.
     Writing a [PostgreSQL] application? Write SQL scripts for [`psql`]. Writing
-    an [Oracle]-backed app? Write SQL scripts for [SQL\*Plus].
+    an [Oracle][orcl]-backed app? Write SQL scripts for [SQL\*Plus].
 
 *   Dependency resolution
 
@@ -176,13 +186,23 @@ SOFTWARE.
   [🍥]:        https://packages.debian.org/stable/sqitch "Latest version on Debian"
   [Postgres]:  https://github.com/sqitchers/sqitch/actions/workflows/pg.yml/badge.svg
   [🐘]:        https://github.com/sqitchers/sqitch/actions/workflows/pg.yml "Tested with PostgreSQL 9.3–14"
+  [Yugabyte]:  https://github.com/sqitchers/sqitch/actions/workflows/yugabyte.yml/badge.svg
+  [🚀]:        https://github.com/sqitchers/sqitch/actions/workflows/yugabyte.yml "Tested with YugabyteDB 2.6–2.13"
   [Vertica]:   https://github.com/sqitchers/sqitch/actions/workflows/vertica.yml/badge.svg
   [🔺]:        https://github.com/sqitchers/sqitch/actions/workflows/vertica.yml "Tested with Vertica 7.1–11.0"
 
   [Sqitch]: https://sqitch.org/
   [PostgreSQL]: https://postgresql.org/
+  [YugabyteDB]: https://www.yugabyte.com/yugabytedb/
+  [lite]: https://sqlite.org/
+  [my]: https://dev.mysql.com/
+  [MariaDB]: https://mariadb.org
   [`psql`]: https://www.postgresql.org/docs/current/static/app-psql.html
-  [Oracle]: https://www.oracle.com/database/
+  [orcl]: https://www.oracle.com/database/
+  [bird]: https://www.firebirdsql.org/
+  [vert]: https://www.vertica.com/
+  [exa]: https://www.exasol.com/
+  [flake]: https://www.snowflake.net/
   [SQL\*Plus]: https://www.orafaq.com/wiki/SQL*Plus
   [Merkle tree]: https://en.wikipedia.org/wiki/Merkle_tree "Wikipedia: “Merkle tree”"
   [gitmerkle]: https://stackoverflow.com/a/18589734/

--- a/lib/App/Sqitch/Command/upgrade.pm
+++ b/lib/App/Sqitch/Command/upgrade.pm
@@ -7,7 +7,6 @@ use utf8;
 use Moo;
 use App::Sqitch::Types qw(URI Maybe Str Bool HashRef);
 use Locale::TextDomain qw(App-Sqitch);
-use Type::Utils qw(enum);
 use App::Sqitch::X qw(hurl);
 use List::Util qw(first);
 use namespace::autoclean;

--- a/lib/sqitch-config.pod
+++ b/lib/sqitch-config.pod
@@ -437,7 +437,7 @@ The database engine to use. Supported engines include:
 
 =over
 
-=item * C<pg> - L<PostgreSQL|https://postgresql.org/> and L<Postgres-XC|https://sourceforge.net/>
+=item * C<pg> - L<PostgreSQL|https://postgresql.org/>, L<Postgres-XC|https://sourceforge.net/projects/postgres-xc/>, and L<YugabyteDB|https://www.yugabyte.com/yugabytedb/>
 
 =item * C<sqlite> - L<SQLite|https://sqlite.org/>
 

--- a/lib/sqitch-init.pod
+++ b/lib/sqitch-init.pod
@@ -37,7 +37,7 @@ include:
 
 =over
 
-=item * C<pg> - L<PostgreSQL|https://postgresql.org/> and L<Postgres-XC|https://sourceforge.net/>
+=item * C<pg> - C<pg> - L<PostgreSQL|https://postgresql.org/>, L<Postgres-XC|https://sourceforge.net/projects/postgres-xc/>, and L<YugabyteDB|https://www.yugabyte.com/yugabytedb/>
 
 =item * C<sqlite> - L<SQLite|https://sqlite.org/>
 

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -961,10 +961,10 @@ sub run {
         is $engine->latest_change_id(3), $change->id,  'Should get "users" offset 3 from latest';
 
         $state = $engine->current_state;
-        # MySQL's group_concat() and Oracle's collect() do not by default sort
-        # by row order, alas.
+        # MySQL's group_concat(), Oracle's collect(), and Yugabyte's array_agg()
+        # do not by default sort by row order, alas.
         $state->{tags} = [ sort @{ $state->{tags} } ]
-            if $class =~ /::(?:mysql|oracle)$/;
+            if $class =~ /::(?:mysql|oracle)$/ || try { $engine->_provider eq 'yugabyte' };
         is_deeply $state, {
             project         => 'engine',
             change_id       => $barney->id,
@@ -1724,7 +1724,7 @@ sub run {
 
         ######################################################################
         # Test try_lock() and wait_lock().
-        if (my $sql = $p{lock_sql}) {
+        if (my $sql = ($p{lock_sql} || sub {})->($engine)) {
             ok !$engine->dbh->selectcol_arrayref($sql->{is_locked})->[0],
                 'Should not be locked';
             ok $engine->try_lock, 'Try lock';

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -520,19 +520,19 @@ DBIEngineTest->run(
             like $sql_mode, qr/\b\Q$mode\E\b/i, "sql_mode should include $mode";
         }
     },
-    lock_sql => {
-        is_locked  => q{SELECT is_used_lock('sqitch working')},
-        try_lock   => q{SELECT get_lock('sqitch working', 0)},
-        wait_time  => 1, # get_lock() does not support sub-second precision, apparently.
-        async_free => 1,
-        free_lock  => 'SELECT ' . ($dbh ? do {
-            # MySQL 5.5-5.6 and Maria 10.0-10.4 prefer release_lock(), while
-            # 5.7+ and 10.5+ prefer release_all_locks().
-            $dbh->selectrow_arrayref('SELECT version()')->[0] =~ /^(?:5\.[56]|10\.[0-4])/
-                ? q{release_lock('sqitch working')}
-                : 'release_all_locks()'
-        } : ''),
-    },
+        lock_sql => sub { return {
+            is_locked  => q{SELECT is_used_lock('sqitch working')},
+            try_lock   => q{SELECT get_lock('sqitch working', 0)},
+            wait_time  => 1, # get_lock() does not support sub-second precision, apparently.
+            async_free => 1,
+            free_lock  => 'SELECT ' . ($dbh ? do {
+                # MySQL 5.5-5.6 and Maria 10.0-10.4 prefer release_lock(), while
+                # 5.7+ and 10.5+ prefer release_all_locks().
+                $dbh->selectrow_arrayref('SELECT version()')->[0] =~ /^(?:5\.[56]|10\.[0-4])/
+                    ? q{release_lock('sqitch working')}
+                    : 'release_all_locks()'
+            } : ''),
+        } },
 );
 
 done_testing;

--- a/t/pg.t
+++ b/t/pg.t
@@ -345,10 +345,14 @@ DBIEngineTest->run(
         is $dbh->selectcol_arrayref('SELECT current_schema')->[0],
             $reg2, 'The Sqitch schema should be the current schema';
     },
-    lock_sql => {
-        is_locked => q{SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND objid = 75474063 AND objsubid = 1},
-        try_lock  => 'SELECT pg_try_advisory_lock(75474063)',
-        free_lock => 'SELECT pg_advisory_unlock_all()',
+    lock_sql => sub {
+        my $engine = shift;
+        return {
+            is_locked => q{SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND objid = 75474063 AND objsubid = 1},
+            try_lock  => 'SELECT pg_try_advisory_lock(75474063)',
+            free_lock => 'SELECT pg_advisory_unlock_all()',
+        } if $engine->_provider ne 'yugabyte';
+        return undef;
     },
 );
 

--- a/xt/release/pod-spelling.t
+++ b/xt/release/pod-spelling.t
@@ -121,3 +121,4 @@ VM
 XC
 yay
 Yay
+YugabyteDB


### PR DESCRIPTION
Works great with the Postgres engine except for locks. So detect that it's Yugabyte and don't create the locks if it is. Change the handling of the `lock_sql` option in the database tests to take a code reference instead of a hash reference, and only return the locking instructions in `t/pg.t` if the engine is not Yugabyte. Mention the Yugabyte support here and there.

Alway sort the current state test tags for Yugabyte, as previously done only for Oracle and MySQL. The Postgres aggregate docs say that the ordering of `array_agg()` is undefined, though it has been reliable in all testing. Not so for Yugabyte. So we force the sort for Yugabyte, but also added #636 to propose a better path forward for aggregate sorting

Add GitHub Actions testing for Yugabyte 2.6 and higher, and link it in the README. While at it, clean up the README, properly listing all supported engines and linking to them.
