### PR TITLE
More coverage

### DIFF
--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [[🐧, ubuntu], [🍎, macos], [🪟, windows]]
-        perl: [ '5.34', '5.32', '5.30', '5.28', '5.26', '5.24', '5.22', '5.20', '5.18', '5.16', '5.14', '5.12' ]
+        perl: [ '5.36', '5.34', '5.32', '5.30', '5.28', '5.26', '5.24', '5.22', '5.20', '5.18', '5.16', '5.14', '5.12' ]
         exclude:
           - { os: [🪟, windows], perl: '5.12' } # https://github.com/shogo82148/actions-setup-perl/issues/876
           - { os: [🪟, windows], perl: '5.14' } # https://github.com/shogo82148/actions-setup-perl/issues/881

--- a/dist/cpanfile
+++ b/dist/cpanfile
@@ -97,6 +97,7 @@ on 'test' => sub {
   requires "Test::Deep" => "0";
   requires "Test::Dir" => "0";
   requires "Test::Exception" => "0";
+  requires "Test::Exit" => "0";
   requires "Test::File" => "0";
   requires "Test::File::Contents" => "0.20";
   requires "Test::MockModule" => "0.17";

--- a/dist/sqitch.spec
+++ b/dist/sqitch.spec
@@ -65,6 +65,7 @@ BuildRequires:  perl(Term::ANSIColor) >= 2.02
 BuildRequires:  perl(Test::Deep)
 BuildRequires:  perl(Test::Dir)
 BuildRequires:  perl(Test::Exception)
+BuildRequires:  perl(Test::Exit)
 BuildRequires:  perl(Test::File)
 BuildRequires:  perl(Test::File::Contents) >= 0.20
 BuildRequires:  perl(Test::MockModule) >= 0.17

--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -264,15 +264,13 @@ sub _parse_core_opts {
 
     # Handle version request.
     if ( delete $opts{version} ) {
-        require File::Basename;
-        my $fn = File::Basename::basename($0);
-        print $fn, ' (', __PACKAGE__, ') ', __PACKAGE__->VERSION, "\n";
+        $self->emit( _bn($0), ' (', __PACKAGE__, ') ', __PACKAGE__->VERSION );
         exit;
     }
 
     # Handle --etc-path.
     if ( $opts{etc_path} ) {
-        say App::Sqitch::Config->class->system_dir;
+        $self->emit( App::Sqitch::Config->class->system_dir );
         exit;
     }
 

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1068,7 +1068,6 @@ sub _timeout {
         return 0 if $secs < 0;
         sleep $secs;
     }
-    return 0;
 }
 
 sub try_lock { 1 }

--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -431,7 +431,6 @@ sub run_verify {
 
 sub run_upgrade {
     my ($self, $file) = @_;
-    my $dbh = $self->dbh;
     my @cmd = $self->mysql;
     $cmd[1 + firstidx { $_ eq '--database' } @cmd ] = $self->registry;
     return $self->sqitch->run( @cmd, $self->_source($file) )
@@ -441,7 +440,8 @@ sub run_upgrade {
     (my $sql = scalar $file->slurp) =~ s{DATETIME\(\d+\)}{DATETIME}g;
 
     # Strip out 5.5 stuff on earlier versions.
-    $sql =~ s/-- ## BEGIN 5[.]5.+?-- ## END 5[.]5//ms if $dbh->{mysql_serverversion} < 50500;
+    $sql =~ s/-- ## BEGIN 5[.]5.+?-- ## END 5[.]5//ms
+        if $self->dbh->{mysql_serverversion} < 50500;
 
     # Write out a temp file and execute it.
     require File::Temp;

--- a/lib/App/Sqitch/Engine/vertica.pm
+++ b/lib/App/Sqitch/Engine/vertica.pm
@@ -259,7 +259,6 @@ sub _select_state {
 
 sub current_state {
     my ( $self, $project ) = @_;
-    my $dbh    = $self->dbh;
     my $state  = try {
         $self->_select_state($project, 1)
     } catch {
@@ -268,7 +267,7 @@ sub current_state {
         die $_;
     } or return undef;
 
-    $state->{tags} = $dbh->selectcol_arrayref(
+    $state->{tags} = $self->dbh->selectcol_arrayref(
         'SELECT tag FROM tags WHERE change_id = ? ORDER BY committed_at',
         undef, $state->{change_id}
     );

--- a/t/engine.t
+++ b/t/engine.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 use utf8;
-use Test::More tests => 720;
+use Test::More tests => 721;
 # use Test::More 'no_plan';
 use App::Sqitch;
 use App::Sqitch::Plan;
@@ -367,7 +367,6 @@ my $plan = $target->plan;
 # timestamps.
 my $mock_dt = Test::MockModule->new('App::Sqitch::DateTime');
 $mock_dt->mock(now => $now);
-
 
 for my $spec (
     [ 'no change' => [] ],
@@ -3416,6 +3415,12 @@ is_deeply +MockOutput->get_info, [[__x(
     secs => $engine->lock_timeout,
 )]], 'Should have notified user of waiting for lock';
 is_deeply $engine->seen, ['wait_lock'], 'wait_lock should have been called';
+
+##############################################################################
+# Test planned_deployed_common_ancestor_id.
+is $engine->planned_deployed_common_ancestor_id,
+    '0539182819c1f0cb50dc4558f4f80b1a538a01b2',
+    'Test planned_deployed_common_ancestor_id';
 
 ##############################################################################
 # Test default implementations.

--- a/t/engine.t
+++ b/t/engine.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 use utf8;
-use Test::More tests => 705;
+use Test::More tests => 720;
 # use Test::More 'no_plan';
 use App::Sqitch;
 use App::Sqitch::Plan;
@@ -349,6 +349,9 @@ for my $abs (qw(
     registered_projects
     change_offset_from_id
     change_id_offset_from_id
+    wait_lock
+    registry_version
+    _update_script_hashes
 )) {
     throws_ok { $engine->$abs } qr/\Q$CLASS has not implemented $abs()/,
         "Should get an unimplemented exception from $abs()"
@@ -360,7 +363,7 @@ can_ok $engine, '_load_changes';
 my $now = App::Sqitch::DateTime->now;
 my $plan = $target->plan;
 
-# Mock App::Sqitch::DateTime so that dbchange tags all have the same
+# Mock App::Sqitch::DateTime so that change tags all have the same
 # timestamps.
 my $mock_dt = Test::MockModule->new('App::Sqitch::DateTime');
 $mock_dt->mock(now => $now);
@@ -829,7 +832,27 @@ is_deeply +MockOutput->get_info_literal, [[
 ]], 'Output should reflect logged reversion';
 is_deeply +MockOutput->get_info, [[__ 'ok']],
     'Output should acknowldge revert success';
+
+# Have the log throw an error.
+$die = 'log_revert_change';
+throws_ok { $engine->revert_change($change) }
+    'App::Sqitch::X', 'Should die on unknown revert logging error';
+is $@->ident, 'revert', 'Sould have revert ident error';
+is $@->message, 'Revert failed','Should get revert failure error message';
+is_deeply $engine->seen, [
+    ['begin_work'],
+    ['finish_work'],
+], 'Log failure should not have seen log_rever_change';
+is_deeply +MockOutput->get_info_literal, [[
+    '  - foo ..', '..', ' '
+]], 'Output should reflect reversion';
+is_deeply +MockOutput->get_info, [[__ 'not ok']],
+    'Output should acknowldge success failure';
+is_deeply +MockOutput->get_vent, [
+    ['AAAH!'],
+], 'The logging error should have been vented';
 $record_work = 0;
+$die = '';
 
 ##############################################################################
 # Test earliest_change() and latest_change().
@@ -1091,7 +1114,7 @@ is_deeply +MockOutput->get_info, [
 # Start with widgets.
 $latest_change_id = $changes[2]->id;
 throws_ok { $engine->deploy('@alpha') } 'App::Sqitch::X',
-    'Should fail changeing older change';
+    'Should fail deploying older change';
 is $@->ident, 'deploy', 'Should be a "deploy" error';
 is $@->message,  __ 'Cannot deploy to an earlier change; use "revert" instead',
     'It should suggest using "revert"';
@@ -1883,7 +1906,7 @@ my @dbchanges;
 } @changes[0..3];
 
 MockOutput->ask_yes_no_returns(1);
-ok $engine->revert, 'Revert all changes';
+is $engine->revert, $engine, 'Revert all changes';
 is_deeply $engine->seen, [
     [lock_destination => []],
     [deployed_changes => undef],
@@ -3393,6 +3416,14 @@ is_deeply +MockOutput->get_info, [[__x(
     secs => $engine->lock_timeout,
 )]], 'Should have notified user of waiting for lock';
 is_deeply $engine->seen, ['wait_lock'], 'wait_lock should have been called';
+
+##############################################################################
+# Test default implementations.
+is $engine->key, 'whu', 'Should have key';
+is $engine->driver, $engine->key, 'Driver should be the same as engine';
+ok $CLASS->try_lock, 'Default try_lock should return true by default';
+is $CLASS->begin_work, $CLASS, 'Default begin_work should return self';
+is $CLASS->finish_work, $CLASS, 'Default finish_work should return self';
 
 __END__
 diag $_->format_name_with_tags for @changes;

--- a/t/vertica.t
+++ b/t/vertica.t
@@ -244,7 +244,7 @@ is_deeply \@run, [$vta->vsql, '--file', 'foo/bar.sql'],
 $mock_sqitch->unmock_all;
 
 ##############################################################################
-# Test DateTime formatting stuff.
+# Test DateTime formatting and other database stuff.
 ok my $ts2char = $CLASS->can('_ts2char_format'), "$CLASS->can('_ts2char_format')";
 is sprintf($ts2char->(), 'foo'),
     q{to_char(foo AT TIME ZONE 'UTC', '"year":YYYY:"month":MM:"day":DD:"hour":HH24:"minute":MI:"second":SS:"time_zone":"UTC"')},
@@ -261,6 +261,23 @@ is $dt->hour,   15, 'DateTime hour should be set';
 is $dt->minute,  7, 'DateTime minute should be set';
 is $dt->second,  1, 'DateTime second should be set';
 is $dt->time_zone->name, 'UTC', 'DateTime TZ should be set';
+is $vta->_listagg_format, undef, 'Should have no listagg format';
+
+##############################################################################
+# Test table error methods.
+DBI: {
+    local *DBI::state;
+    ok !$vta->_no_table_error, 'Should have no table error';
+    ok !$vta->_no_column_error, 'Should have no column error';
+
+    $DBI::state = '42V01';
+    ok $vta->_no_table_error, 'Should now have table error';
+    ok !$vta->_no_column_error, 'Still should have no column error';
+
+    $DBI::state = '42703';
+    ok !$vta->_no_table_error, 'Should again have no table error';
+    ok $vta->_no_column_error, 'Should now have no column error';
+}
 
 ##############################################################################
 # Can we do live tests?


### PR DESCRIPTION
Properly test a bunch of stuff that had no coverage, like the MySQL and Postgres processing of the registry SQL file to support older versions, as well as other stuff that Coveralls reported as uncovered. Gets coverage up to 98.6% (from 97%), and no module has less than 95% coverage now.