### PR TITLE
Explicitly sort aggregated lists

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,10 @@ Revision history for Perl extension App::Sqitch
        App::Sqitch::Engine::pg to make a few changes. The SQL files with
        the registry DDL varies in a few ways, so they're separate.
      - Now require URI::db v0.20 for Cockroach and Yugabyte URI support.
+     - Dropped support for MySQL 5.0.
+     - Added explicit sorting for aggregated lists (such as the tags associated
+       with a commit) to the MySQL, Exasol, Snowflake, and Postgres (8.4 and
+       higher) engines.
 
 1.2.1  2021-12-05T19:59:45Z
      - Updated all the live engine tests, aside from Oracle, to test with

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ App/Sqitch version v1.2.2-dev
 *   [YugabyteDB] 2.6+
 *   [CockroachDB] 21+
 *   [SQLite][lite] 3.7.11+
-*   [MySQL][my] 5.0+
+*   [MySQL][my] 5.1+
 *   [MariaDB] 10.0+
 *   [Oracle][orcl] 10g+,
 *   [Firebird][bird] 2.0+

--- a/dist/sqitch.spec
+++ b/dist/sqitch.spec
@@ -238,7 +238,7 @@ package bundles the Sqitch Oracle support.
 Summary:        Sensible database change management for MySQL
 Group:          Development/Libraries
 Requires:       sqitch >= %{version}
-Requires:       mysql >= 5.0.0
+Requires:       mysql >= 5.1.0
 Requires:       perl(DBI)
 Requires:       perl(DBD::mysql) >= 4.018
 Requires:       perl(MySQL::Config)

--- a/etc/tools/upgrade-registry-to-mysql-5.5.0.sql
+++ b/etc/tools/upgrade-registry-to-mysql-5.5.0.sql
@@ -3,7 +3,7 @@
 -- it to emulate CHECK constraints. It will then also be available for use in
 -- verify scripts, as described in sqitchtutorial-mysql. If you have an
 -- existing Sqitch registry that was upgraded from an earlier version of MySQL
--- to 5.5.0 or highher, you'll need to run this script to update it, like so:
+-- to 5.5.0 or higher, you'll need to run this script to update it, like so:
 
 --      mysql -u root sqitch --execute "source `sqitch --etc`/tools/upgrade-registry-to-mysql-5.5.0.sql'
 

--- a/etc/tools/upgrade-registry-to-mysql-5.6.4.sql
+++ b/etc/tools/upgrade-registry-to-mysql-5.6.4.sql
@@ -1,7 +1,7 @@
 -- This script upgrades the Sqitch registry for MySQL 5.6.4 and higher. Sqitch
 -- expects datetime columns to have a precision on 5.6.4 and higher. If you have
 -- an existing Sqitch registry that was upgraded from an earlier version of MySQL
--- to 5.6.4 or highher, you'll need to run this script to update it, like so:
+-- to 5.6.4 or higher, you'll need to run this script to update it, like so:
 
 --      mysql -u root sqitch --execute "source `sqitch --etc`/tools/upgrade-registry-to-mysql-5.6.4.sql'
 

--- a/lib/App/Sqitch/Engine/exasol.pm
+++ b/lib/App/Sqitch/Engine/exasol.pm
@@ -181,7 +181,7 @@ sub _ts2char_format {
 sub _ts_default { 'current_timestamp' }
 
 sub _listagg_format {
-    return q{GROUP_CONCAT(%s SEPARATOR ' ')};
+    return q{GROUP_CONCAT(%1$s ORDER BY %1$s SEPARATOR ' ')};
 }
 
 sub _regex_op { 'REGEXP_LIKE' }

--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -121,7 +121,7 @@ has dbh => (
         # Make sure we support this version.
         my ($dbms, $vnum, $vstr) = $dbh->{mysql_serverinfo} =~ /mariadb/i
             ? ('MariaDB', 50300, '5.3')
-            : ('MySQL',   50000, '5.0.0');
+            : ('MySQL',   50100, '5.1.0');
         hurl mysql => __x(
             'Sqitch requires {rdbms} {want_version} or higher; this is {have_version}',
             rdbms        => $dbms,
@@ -348,7 +348,7 @@ sub _regex_op { 'REGEXP' }
 sub _limit_default { '18446744073709551615' }
 
 sub _listagg_format {
-    return q{GROUP_CONCAT(%s SEPARATOR ' ')};
+    return q{GROUP_CONCAT(%1$s ORDER BY %1$s SEPARATOR ' ')};
 }
 
 sub _prepare_to_log {

--- a/lib/App/Sqitch/Engine/snowflake.pm
+++ b/lib/App/Sqitch/Engine/snowflake.pm
@@ -277,7 +277,7 @@ sub _verbose_opts {
 # * Scalar variables like the array constructor can't be used in WHERE clauses
 #   https://support.snowflake.net/s/case/5000Z000010wX7yQAE/
 sub _listagg_format {
-    return q{listagg(%s, ' ')};
+    return q{listagg(%1$s, ' ') WITHIN GROUP (ORDER BY %1$s)};
 }
 
 sub _ts_default { 'current_timestamp' }

--- a/lib/App/Sqitch/Engine/sqlite.pm
+++ b/lib/App/Sqitch/Engine/sqlite.pm
@@ -188,6 +188,8 @@ sub _ts2char_format {
 }
 
 sub _listagg_format {
+    # The order of the concatenated elements is arbitrary.
+    # https://www.sqlite.org/lang_aggfunc.html
     return q{group_concat(%s, ' ')};
 }
 

--- a/lib/sqitch.pod
+++ b/lib/sqitch.pod
@@ -22,7 +22,7 @@ Sqitch is a database change management application. It currently supports:
 
 =item * L<SQLite|https://sqlite.org/> 3.7.11+
 
-=item * L<MySQL|https://dev.mysql.com/> 5.0+
+=item * L<MySQL|https://dev.mysql.com/> 5.1+
 
 =item * L<MariaDB|https://mariadb.org> 10.0+
 

--- a/t/exasol.t
+++ b/t/exasol.t
@@ -326,7 +326,8 @@ is $exa->_char2ts($dt), '2017-11-06 10:47:35',
 
 ##############################################################################
 # Test SQL helpers.
-is $exa->_listagg_format, q{GROUP_CONCAT(%s SEPARATOR ' ')}, 'Should have _listagg_format';
+is $exa->_listagg_format, q{GROUP_CONCAT(%1$s ORDER BY %1$s SEPARATOR ' ')},
+    'Should have _listagg_format';
 is $exa->_ts_default, 'current_timestamp', 'Should have _ts_default';
 is $exa->_regex_op, 'REGEXP_LIKE', 'Should have _regex_op';
 is $exa->_simple_from, ' FROM dual', 'Should have _simple_from';

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -961,10 +961,8 @@ sub run {
         is $engine->latest_change_id(3), $change->id,  'Should get "users" offset 3 from latest';
 
         $state = $engine->current_state;
-        # MySQL's group_concat() and Oracle's collect() do not by default sort
-        # by row order, alas.
-        $state->{tags} = [ sort @{ $state->{tags} } ]
-            if $class =~ /::(?:mysql|oracle)$/;
+        # Oracle's collect() does not by default sort by row order, alas.
+        $state->{tags} = [ sort @{ $state->{tags} } ] if $class =~ /::oracle$/;
         is_deeply $state, {
             project         => 'engine',
             change_id       => $barney->id,

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -366,7 +366,8 @@ is $dt->time_zone->name, 'UTC', 'DateTime TZ should be set';
 
 ##############################################################################
 # Test SQL helpers.
-is $mysql->_listagg_format, q{GROUP_CONCAT(%s SEPARATOR ' ')}, 'Should have _listagg_format';
+is $mysql->_listagg_format, q{GROUP_CONCAT(%1$s ORDER BY %1$s SEPARATOR ' ')},
+    'Should have _listagg_format';
 is $mysql->_regex_op, 'REGEXP', 'Should have _regex_op';
 is $mysql->_simple_from, '', 'Should have _simple_from';
 is $mysql->_limit_default, '18446744073709551615', 'Should have _limit_default';
@@ -598,8 +599,8 @@ my $err = try {
             unless $dbh->{mysql_serverversion} >= 50300;
     }
     else {
-        die "MySQL >= 50000 required; this is $dbh->{mysql_serverversion}\n"
-            unless $dbh->{mysql_serverversion} >= 50000;
+        die "MySQL >= 50100 required; this is $dbh->{mysql_serverversion}\n"
+            unless $dbh->{mysql_serverversion} >= 50100;
     }
 
     $dbh->do("CREATE DATABASE $db");

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -336,7 +336,8 @@ is_deeply [$snow->snowsql], [qw(
 
 ##############################################################################
 # Test SQL helpers.
-is $snow->_listagg_format, q{listagg(%s, ' ')}, 'Should have _listagg_format';
+is $snow->_listagg_format, q{listagg(%1$s, ' ') WITHIN GROUP (ORDER BY %1$s)},
+    'Should have _listagg_format';
 is $snow->_ts_default, 'current_timestamp', 'Should have _ts_default';
 is $snow->_regex_op, 'REGEXP', 'Should have _regex_op';
 is $snow->_simple_from, ' FROM dual', 'Should have _simple_from';


### PR DESCRIPTION
Wherever we can.

*   Drop MySQL 5.0 and use the feature from 5.1 or later
*   Add ORDER By to the listagg expression for Exasol, MySQL, and Snowflake
*   Add a comment documenting the arbitrary order in SQLite (though tests
    show it is not currently arbitrary)

Resolves #636.