### PR TITLE
Lock destination after registry creation

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Revision history for Perl extension App::Sqitch
        higher) engines.
      - Fixed slow deploys on MariaDB thanks to fractional timestamp support
        added in 5.03.05. Thanks to @rbrigot for the PR (#658)!
+     - Fixed a bug where destination locking failed on the first deploy to
+       MySQL. Bug introduced along with destination locking in v1.2.0.
+       Thanks Tom Bloor the report and to Alberto Simões for the help
+       replicating the issue (#601).
 
 1.2.1  2021-12-05T19:59:45Z
      - Updated all the live engine tests, aside from Oracle, to test with

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -270,11 +270,13 @@ sub deploy {
 
 sub revert {
     my ( $self, $to ) = @_;
-    $self->lock_destination;
+
+    # Check the registry and, once we know it's there, lock the destination.
     $self->_check_registry;
+    $self->lock_destination;
+
     my $sqitch = $self->sqitch;
     my $plan   = $self->plan;
-
     my @changes;
 
     if (defined $to) {


### PR DESCRIPTION
Turns out that v1.2.0 introduced a bug when trying to deploy to a MySQL server that does not already have a registry database (usually named "sqitch"). It would fail because it could not connect to the registry. Which makes sense, since on first deploy it does not usually exist yet.

So initialize the MySQL registry if it does not exist, and move revert's call to lock the destination to after we're certain the registry exists. Since this might increase the calls to `initialized()`, change it to an attribute to cut down on the database calls.

Resolves #601.
