### PR TITLE
Extend test coverage to 100%

### DIFF
--- a/.github/workflows/cockroach.yml
+++ b/.github/workflows/cockroach.yml
@@ -1,7 +1,7 @@
 # This workflow tests Sqitch's Cockroach engine on all supported versions of
 # Postgres. It runs for pushes and pull requests on the `main`, `develop`,
 # `**cockroach**`, and `**engine**` branches.
-name: 🪳 CockroachDB
+name: 🪳 Cockroach
 on:
   push:
     branches: [main, develop, "**engine**", "**cockroach**" ]

--- a/.github/workflows/yugabyte.yml
+++ b/.github/workflows/yugabyte.yml
@@ -1,7 +1,7 @@
 # This workflow tests Sqitch's PostgreSQL engine on all supported versions of
 # YugabyteDB. It runs for pushes and pull requests on the `main`, `develop`,
 # `**postgres**`, `**yugabyte**`, and `**engine**` branches.
-name: 💫 YugabyteDB
+name: 💫 Yugabyte
 on:
   push:
     branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
@@ -16,7 +16,7 @@ jobs:
           - { version: '2.12', tag: 2.12.5.0-b24  }
           - { version: '2.8',  tag: 2.8.6.0-b12   }
           - { version: '2.6',  tag: 2.6.18.0-b3   }
-    name: 💫 YugabyteDB ${{ matrix.version }}
+    name: 💫 Yugabyte ${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup YugabyteDB cluster

--- a/Changes
+++ b/Changes
@@ -23,6 +23,10 @@ Revision history for Perl extension App::Sqitch
        MySQL. Bug introduced along with destination locking in v1.2.0.
        Thanks Tom Bloor the report and to Alberto Simões for the help
        replicating the issue (#601).
+     - Removed the `sqitch engine update-config` action, originally added for
+       compatibility reasons in 2014, and the prompt to use it was removed as
+       of 0.9999 in 2019.
+     - Fixed a warning when searching for the Firebird client on Windows.
 
 1.2.1  2021-12-05T19:59:45Z
      - Updated all the live engine tests, aside from Oracle, to test with

--- a/lib/App/Sqitch/Command.pm
+++ b/lib/App/Sqitch/Command.pm
@@ -8,6 +8,7 @@ use Try::Tiny;
 use Locale::TextDomain qw(App-Sqitch);
 use App::Sqitch::X qw(hurl);
 use Hash::Merge 'merge';
+use File::Path qw(make_path);
 use Moo;
 use App::Sqitch::Types qw(Sqitch Target);
 
@@ -239,7 +240,7 @@ sub parse_args {
         $seen{$target->name}++;
     }
 
-    # Iterate over the argsx to look for changes, engines, plans, or targets.
+    # Iterate over the args to look for changes, engines, plans, or targets.
     my %engines = map { $_ => 1 } ENGINES;
     for my $arg (@{ $p{args} }) {
         if ( !$p{no_changes} && $target && -e $target->plan_file && $target->plan->contains($arg) ) {
@@ -307,6 +308,22 @@ sub parse_args {
     }
 
     return (@names, \@targets, $rec{changes});
+}
+
+sub _mkpath {
+    my ( $self, $dir ) = @_;
+    $self->debug( '    ', __x 'Created {file}', file => $dir )
+        if make_path $dir, { error => \my $err };
+
+    my $diag = shift @{ $err } or return $self;
+
+    my ( $path, $msg ) = %{ $diag };
+    hurl $self->command => __x(
+        'Error creating {path}: {error}',
+        path  => $path,
+        error => $msg,
+    ) if $path;
+    hurl $self->command => $msg;
 }
 
 1;

--- a/lib/App/Sqitch/Command/add.pm
+++ b/lib/App/Sqitch/Command/add.pm
@@ -10,7 +10,6 @@ use Moo;
 use App::Sqitch::Types qw(Str Int ArrayRef HashRef Dir Bool Maybe);
 use Path::Class;
 use Try::Tiny;
-use File::Path qw(make_path);
 use Clone qw(clone);
 use List::Util qw(first);
 use namespace::autoclean;
@@ -372,16 +371,7 @@ sub _add {
     }
 
     # Create the directory for the file, if it does not exist.
-    make_path $file->dir->stringify, { error => \my $err };
-    if ( my $diag = shift @{ $err } ) {
-        my ( $path, $msg ) = %{ $diag };
-        hurl add => __x(
-            'Error creating {path}: {error}',
-            path  => $path,
-            error => $msg,
-        ) if $path;
-        hurl add => $msg;
-    }
+    $self->_mkpath($file->dir->stringify);
 
     my $vars = clone {
         %{ $self->variables },

--- a/lib/App/Sqitch/Command/bundle.pm
+++ b/lib/App/Sqitch/Command/bundle.pm
@@ -129,22 +129,6 @@ sub execute {
     return $self;
 }
 
-sub _mkpath {
-    my ( $self, $dir ) = @_;
-    $self->debug( '    ', __x 'Created {file}', file => $dir )
-        if make_path $dir, { error => \my $err };
-
-    my $diag = shift @{ $err } or return $self;
-
-    my ( $path, $msg ) = %{ $diag };
-    hurl bundle => __x(
-        'Error creating {path}: {error}',
-        path  => $path,
-        error => $msg,
-    ) if $path;
-    hurl bundle => $msg;
-}
-
 sub _copy_if_modified {
     my ( $self, $src, $dst ) = @_;
 

--- a/lib/App/Sqitch/Engine/firebird.pm
+++ b/lib/App/Sqitch/Engine/firebird.pm
@@ -289,7 +289,7 @@ sub _no_table_error  {
 }
 
 sub _no_column_error  {
-    return $DBI::errstr && $DBI::errstr =~ /^-Column unknown|/m;
+    return $DBI::errstr && $DBI::errstr =~ /^-Column unknown/m;
 }
 
 sub _regex_op { 'SIMILAR TO' }               # NOT good match for
@@ -898,7 +898,8 @@ sub default_client {
         my $loops = 0;
         for my $dir (File::Spec->path) {
             my $path = file $dir, $try;
-            $path = Win32::GetShortPathName($path) if App::Sqitch::ISWIN;
+            # GetShortPathName returns undef for nonexistent files.
+            $path = Win32::GetShortPathName($path) // next if App::Sqitch::ISWIN;
             if (-f $path && -x $path) {
                 if (try { App::Sqitch->probe($path, @opts) =~ /Firebird/ } ) {
                     # Restore STDERR and return.

--- a/lib/App/Sqitch/Engine/oracle.pm
+++ b/lib/App/Sqitch/Engine/oracle.pm
@@ -423,19 +423,22 @@ sub is_deployed_tag {
 
 sub are_deployed_changes {
     my $self = shift;
+    @{ $self->dbh->selectcol_arrayref(
+        'SELECT change_id FROM changes WHERE ' . _change_id_in(scalar @_),
+        undef,
+        map { $_->id } @_,
+    ) };
+}
+
+sub _change_id_in {
+    my $i = shift;
     my @qs;
-    my $i = @_;
     while ($i > 250) {
         push @qs => 'change_id IN (' . join(', ' => ('?') x 250) . ')';
         $i -= 250;
     }
     push @qs => 'change_id IN (' . join(', ' => ('?') x $i) . ')' if $i > 0;
-    my $expr = join ' OR ', @qs;
-    @{ $self->dbh->selectcol_arrayref(
-        "SELECT change_id FROM changes WHERE $expr",
-        undef,
-        map { $_->id } @_,
-    ) };
+    return join ' OR ', @qs;
 }
 
 sub _registry_variable {

--- a/lib/App/Sqitch/Engine/sqlite.pm
+++ b/lib/App/Sqitch/Engine/sqlite.pm
@@ -172,7 +172,7 @@ sub _no_table_error  {
 }
 
 sub _no_column_error  {
-    return try { $_->message =~ /^\Qno such column:/ };
+    return $DBI::errstr && $DBI::errstr =~ /^\Qno such column:/;
 }
 
 sub _regex_op { 'REGEXP' }

--- a/lib/sqitch-bundle.pod
+++ b/lib/sqitch-bundle.pod
@@ -4,7 +4,7 @@ sqitch-bundle - Bundle a Sqitch project for distribution
 
 =head1 Synopsis
 
-  sqitch bundle [options
+  sqitch bundle [options]
   sqitch bundle --dest-dir widgets-1.0.0
   sqitch bundle --all
   sqitch bundle pg mysql

--- a/lib/sqitch-engine-usage.pod
+++ b/lib/sqitch-engine-usage.pod
@@ -10,7 +10,6 @@ sqitch-engine-usage - Sqitch engine usage statement
   sqitch engine alter <name> [engine-options]
   sqitch engine remove <name>
   sqitch engine show <name>
-  sqitch engine update-config
 
 =head1 Options
 

--- a/lib/sqitch-engine.pod
+++ b/lib/sqitch-engine.pod
@@ -10,7 +10,6 @@ sqitch-engine - Manage database engine configuration
   sqitch engine alter <name> [engine-options]
   sqitch engine remove <name>
   sqitch engine show <name>
-  sqitch engine update-config
 
 =head1 Description
 
@@ -251,11 +250,6 @@ and script directories will not be affected.
 Gives some information about the engine C<< <name> >>, including the
 associated properties. Specify multiple engine names to see information for
 each.
-
-=head2 C<update-config>
-
-Update the configuration from a configuration file that predates the addition
-of the C<engine> command to Sqitch.
 
 =head1 Configuration Variables
 

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1638,13 +1638,3 @@ msgstr "L'email utente non può contenere \">\"."
 
 #~ msgid "The @{old} symbolic tag has been deprecated; use @{new} instead"
 #~ msgstr "Il tag simbolico @{old} è stato deprecato; usa @{new} al suo posto."
-
-#~ msgid ""
-#~ "The core.{engine} config has been deprecated in favor of engine."
-#~ "{engine}.\n"
-#~ "Run '{sqitch} engine update-config' to update your configurations."
-#~ msgstr ""
-#~ "La configurazione core.{engine} è stata deprecata a favore di engine."
-#~ "{engine}.\n"
-#~ "Esegui '{sqitch} engine update-config` per aggiornare la tua "
-#~ "configurazione."

--- a/t/add.t
+++ b/t/add.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 236;
+use Test::More tests => 238;
 #use Test::More 'no_plan';
 use App::Sqitch;
 use App::Sqitch::Target;
@@ -626,7 +626,14 @@ USAGE: {
         'No name arg or option should yield usage';
     is_deeply \@args, [$add], 'No args should be passed to usage';
 
-    # Should be true when no engine is specified, either.
+    # Should get usage when no change name passed or specified.
+    @args = ();
+    throws_ok { $add->execute('pg') } qr/USAGE/,
+        'No name arg or option should yield usage';
+    is_deeply \@args, [$add], 'No args should be passed to usage';
+
+    # Should get usage when no engine is specified, either.
+    @args = ();
     $add = $CLASS->new(sqitch => App::Sqitch->new(config => TestConfig->new));
     throws_ok { $add->execute } qr/USAGE/,
         'No name arg or option should yield usage';

--- a/t/configuration.t
+++ b/t/configuration.t
@@ -80,7 +80,8 @@ is_deeply $config->get_section(section => 'engine.pg'), {
 
 # Make sure it works with irregular casing.
 is_deeply $config->get_section(section => 'foo.BAR'), {
-    baz => 'hello'
+    baz => 'hello',
+    yep => undef,
 }, 'get_section() whould work with capitalized subsection';
 
 # Should work with multiple subsections and case-preserved keys.

--- a/t/dbiengine_role.t
+++ b/t/dbiengine_role.t
@@ -1,0 +1,130 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use 5.010;
+use utf8;
+use Test::More tests => 14;
+# use Test::More 'no_plan';
+use Test::MockModule;
+use Test::Exception;
+
+# For testing paths in App::Sqitch::Role::DBIEngine that are not implicictly
+# tested by the engines that use it.
+
+my $CLASS;
+
+BEGIN {
+    $CLASS = 'App::Sqitch::Role::DBIEngine';
+    require_ok $CLASS or die;
+}
+
+can_ok $CLASS, qw(
+    _dt
+    _log_tags_param
+    _log_requires_param
+    _log_conflicts_param
+    _ts_default
+    _can_limit
+    _limit_default
+    _simple_from
+    _quote_idents
+    _in_expr
+    _register_release
+    _version_query
+    registry_version
+    _cid
+    earliest_change_id
+    latest_change_id
+    _select_state
+    current_state
+    current_changes
+    current_tags
+    search_events
+    _regex_expr
+    _limit_offset
+    registered_projects
+    register_project
+    is_deployed_change
+    are_deployed_changes
+    is_deployed_tag
+    _multi_values
+    _dependency_placeholders
+    _tag_placeholders
+    _tag_subselect_columns
+    _prepare_to_log
+    log_deploy_change
+    log_fail_change
+    _log_event
+    changes_requiring_change
+    name_for_change_id
+    log_new_tags
+    log_revert_change
+    deployed_changes
+    deployed_changes_since
+    load_change
+    _offset_op
+    change_id_offset_from_id
+    change_offset_from_id
+    _cid_head
+    change_id_for
+    _update_script_hashes
+    begin_work
+    finish_work
+    rollback_work
+);
+
+is App::Sqitch::Role::DBIEngine::_ts_default, 'DEFAULT',
+    '_ts_default shoudld return DEFAULT';
+
+# Test various failure modes.
+my $role = bless {} => $CLASS;
+FAILMOCKS: {
+    # Set up mocks.
+    my $mock = Test::MockModule->new($CLASS);
+    my ($dbh_err, $no_table, $no_col, $init) = ('OW', 0, 0, 0);
+    my ($state_err, $sel_state) = ('OOPS', -1);
+    $mock->mock(dbh => sub { die $dbh_err });
+    $mock->mock(_no_table_error => sub { $no_table });
+    $mock->mock(initialized => sub { $init });
+    $mock->mock(_no_column_error => sub { $no_col });
+    $mock->mock(_select_state => sub { $sel_state = $_[2]; die $state_err });
+
+    # Test registry_version.
+    throws_ok { $role->registry_version } qr/OW/,
+        'registry_version should propagate non-table error';
+    $no_table = 1;
+    ok !$role->registry_version,
+        'registry_version should return false on no-table error';
+    $no_table = 0;
+
+    # Test _cid
+    throws_ok { $role->_cid(0, 0, 'foo') } qr/OW/,
+        '_cid should propagate non-table error';
+    $no_table = 1;
+    ok !$role->_cid(0, 0, 'foo'),
+        '_cid should return false on no-table error and unititialized';
+    $no_table = 0;
+
+
+    # Test current_state.
+    throws_ok { $role->current_state('foo') } qr/OOPS/,
+        'curent_state should propagate _select_state error';
+    is $sel_state, 1, 'Should have passed 1 to _select_state';
+    ($sel_state, $no_table) = (-1, 1);
+    ok !$role->current_state('foo'),
+        'curent_state should return false on no-table error';
+    is $sel_state, 1, 'Should again have passed 1 to _select_state';
+    ($sel_state, $init, $no_col) = (-1, 1, 1);
+    throws_ok { $role->current_state('foo') } qr/OOPS/,
+        'curent_state should propagate second error on no-column error';
+    is $sel_state, 0, 'Should again have passed 0 to _select_state';
+    ($sel_state, $no_table, $init, $no_col) = (-1, 0, 0, 0);
+
+    # Make sure change_id_for returns undef when no useful params.
+    $mock->mock(dbh => 1);
+    is $role->change_id_for(project => 'foo'), undef,
+        'Should get undef from change_id_for when no useful params';
+}
+
+done_testing;

--- a/t/exasol.t
+++ b/t/exasol.t
@@ -230,6 +230,15 @@ like capture_stderr {
 }, qr/^OMGWTF/m, 'STDERR should be emitted by _capture';
 
 ##############################################################################
+# Test unexpeted datbase error in _cid().
+$mock_exa->mock(dbh => sub { die 'OW' });
+throws_ok { $exa->initialized } qr/OW/,
+    'initialized() should rethrow unexpected DB error';
+throws_ok { $exa->_cid } qr/OW/,
+    '_cid should rethrow unexpected DB error';
+$mock_exa->unmock('dbh');
+
+##############################################################################
 # Test _file_for_script().
 can_ok $exa, '_file_for_script';
 is $exa->_file_for_script(Path::Class::file 'foo'), 'foo',
@@ -246,6 +255,20 @@ my $file = $tmpdir->file('foo@bar.sql');
 $file->touch; # File must exist, because on Windows it gets copied.
 is $exa->_file_for_script($file), $tmpdir->file('foo_bar.sql'),
     'File with special char should be aliased';
+
+# Now the alias exists, make sure _file_for_script dies if it cannot remove it.
+FILE: {
+    my $mock_pcf = Test::MockModule->new('Path::Class::File');
+    $mock_pcf->mock(remove => 0);
+    throws_ok { $exa->_file_for_script($file) } 'App::Sqitch::X',
+        'Should get an error on failure to delete the alias';
+    is $@->ident, 'exasol', 'File deletion error ident should be "exasol"';
+    is $@->message, __x(
+        'Cannot remove {file}: {error}',
+        file  => $tmpdir->file('foo_bar.sql'),
+        error => $!,
+    ), 'File deletion error message should be correct';
+}
 
 # Make sure double-quotes are escaped.
 WIN32: {

--- a/t/firebird.t
+++ b/t/firebird.t
@@ -63,6 +63,7 @@ is $fb->key, 'firebird', 'Key should be "firebird"';
 is $fb->name, 'Firebird', 'Name should be "Firebird"';
 is $fb->username, $ENV{ISC_USER}, 'Should have username from environment';
 is $fb->password, $ENV{ISC_PASSWORD}, 'Should have password from environment';
+is $fb->_limit_default, '18446744073709551615', 'Should have _limit_default';
 
 my $have_fb_client;
 if ($have_fb_driver && (my $client = try { $fb->client })) {
@@ -157,7 +158,6 @@ is $@->message, __x(
     'Database name missing in URI {uri}',
     uri => 'db:firebird:',
 ), 'No dbname exception message should be correct';
-
 
 ##############################################################################
 # Test _run(), _capture(), and _spool().
@@ -278,7 +278,117 @@ is $dt->second,  1, 'DateTime second should be set';
 is $dt->time_zone->name, 'UTC', 'DateTime TZ should be set';
 
 ##############################################################################
+# Test error checking functions.
+DBI: {
+    local *DBI::errstr;
+    ok !$fb->_no_table_error, 'Should have no table error';
+    ok !$fb->_no_column_error, 'Should have no column error';
 
+    $DBI::errstr = '-Table unknown';
+    ok $fb->_no_table_error, 'Should now have table error';
+    ok !$fb->_no_column_error, 'Still should have no column error';
+
+    $DBI::errstr = 'No such file or directory';
+    ok $fb->_no_table_error, 'Should again have table error';
+    ok !$fb->_no_column_error, 'Still should have no column error';
+
+    $DBI::errstr = '-Column unknown';
+    ok !$fb->_no_table_error, 'Should again have no table error';
+    ok $fb->_no_column_error, 'Should now have no column error';
+}
+
+##############################################################################
+# Test database creation failure.
+DBFAIL: {
+    my $mock = Test::MockModule->new($CLASS);
+    $mock->mock(initialized => 0);
+    $mock->mock(use_driver => 1);
+    my $fbmock = Test::MockModule->new('DBD::Firebird', no_auto => 1);
+    $fbmock->mock(create_database => sub { die 'Creation failed' });
+    throws_ok { $fb->initialize } 'App::Sqitch::X',
+        'Should get an error from initialize';
+    is $@->ident, 'firebird', 'No creattion exception ident should be "firebird"';
+    my $msg = __x(
+        'Cannot create database {database}: {error}',
+        database => $fb->connection_string($fb->registry_uri),
+        error => 'Creation failed',
+    );
+    like $@->message, qr{^\Q$msg\E}, 'Creation exception message should be correct';
+}
+
+##############################################################################
+# Test various database connection and error-handling logic.
+DBH: {
+    # Need to mock DBH.
+    my $dbh = DBI->connect('dbi:Mem:', undef, undef, {});
+    my $mock_engine = Test::MockModule->new($CLASS);
+    $mock_engine->mock(dbh => $dbh);
+    $mock_engine->mock(registry_uri => URI->new('db:firebird:foo.fdb'));
+    my $mock_dbd = Test::MockModule->new(ref $dbh, no_auto => 1);
+    my ($disconnect, $clear);
+    $mock_dbd->mock(disconnect => sub { $disconnect = 1 });
+    $mock_engine->mock(_clear_dbh => sub { $clear = 1 });
+    my $run;
+    $mock_sqitch->mock(run => sub { $run = 1 });
+
+    # Test that upgrading disconnects from a local database before upgrading.
+    ok $fb->run_upgrade('somefile'), 'Run the upgrade';
+    ok $disconnect, 'Should have disconnected';
+    ok $clear, 'Should have cleared the database handle';
+    ok $run, 'Should have run a command';
+    $mock_sqitch->unmock('run');
+
+    # Test that _cid propagates an unexpected error from DBI.
+    local *DBI::err;
+    $DBI::err = 0;
+    $mock_engine->mock(dbh => sub { die 'Oops' });
+    throws_ok { $fb->_cid('ASC', 0, 'foo') } qr/^Oops/,
+        '_cid should propagate unexpected error';
+
+    # But it should just return for error code -902.
+    $DBI::err = -902;
+    lives_ok { $fb->_cid('ASC', 0, 'foo') }
+        '_cid should just return on error code -902';
+
+    # Test that current_state returns on no table error.
+    local *DBI::errstr;
+    $DBI::errstr = '-Table unknown';
+    $mock_engine->mock(initialized => 0);
+    lives_ok { $fb->current_state('foo') }
+        'current_state should return on no table error';
+
+    # But it should die if it's not a table error.
+    $DBI::errstr = 'Some other error';
+    throws_ok { $fb->current_state('foo') } qr/^Oops/,
+        'current_state should propagate unexpected error';
+
+    # Make sure change_id_for returns undef when no useful params.
+    $mock_engine->mock(dbh => $dbh);
+    is $fb->change_id_for(project => 'foo'), undef,
+        'Should get undef from change_id_for when no useful params';
+}
+
+# Make sure defaul_client croaks when it finds no client.
+FSPEC: {
+    # Give it an invalid fbsql file to find.
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $tmp = Path::Class::Dir->new("$tmpdir");
+    my $iswin = App::Sqitch::ISWIN || $^O eq 'cygwin';
+    my $fbsql = $tmp->file('fbsql' . ($iswin ? '.exe' : ''));
+    $fbsql->touch;
+    chmod '0755', $fbsql unless $iswin;
+
+    my $fs_mock = Test::MockModule->new('File::Spec');
+    $fs_mock->mock(path => sub { $tmp });
+    throws_ok { $fb->default_client } 'App::Sqitch::X',
+        'Should get error when no client found';
+    is $@->ident, 'firebird', 'Client exception ident should be "firebird"';
+    is $@->message, __(
+        'Unable to locate Firebird ISQL; set "engine.firebird.client" via sqitch config'
+    ), 'Client exception message should be correct';
+}
+
+##############################################################################
 # Can we do live tests?
 my ($data_dir, $fb_version, @cleanup) = ($tmpdir);
 my $id = DBIEngineTest->randstr;

--- a/t/plan_cmd.t
+++ b/t/plan_cmd.t
@@ -3,8 +3,8 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 229;
-#use Test::More 'no_plan';
+use Test::More tests => 232;
+# use Test::More 'no_plan';
 use App::Sqitch;
 use Locale::TextDomain qw(App-Sqitch);
 use Test::NoWarnings;
@@ -25,7 +25,7 @@ require_ok $CLASS;
 my $config = TestConfig->new(
     'core.engine'    => 'sqlite',
     'core.top_dir'   => dir('test-plan_cmd')->stringify,
-    'core.plan_file' => file(qw(t sql sqitch.plan))->stringify,
+    'core.plan_file' => file(qw(t plans dependencies.plan))->stringify,
 );
 ok my $sqitch = App::Sqitch->new(config => $config),
     'Load a sqitch sqitch object';
@@ -621,6 +621,32 @@ is_deeply +MockOutput->get_page, [
     [ $cmd->formatter->format( $cmd->format, $fmt_params2 ) ],
 ], 'Both events should have been paged without headers';
 
+# Now try raw format of all the changes.
+my $cfg = $CLASS->configure( $config, { format => 'raw' } );
+ok $cmd = $CLASS->new( sqitch => $sqitch, %{ $cfg } ),
+    'Create command with raw format';
+push @changes => $plan->changes;
+
+ok $cmd->execute, 'Execute plan with all changes';
+is_deeply +MockOutput->get_page, [
+    ['# ', __x 'Project: {project}', project => $plan->project ],
+    ['# ', __x 'File:    {file}', file => $plan->file ],
+    [''],
+    map { [ $cmd->formatter->format( $cmd->format, {
+        event         => $_->is_deploy ? 'deploy' : 'revert',
+        project       => $_->project,
+        change_id     => $_->id,
+        change        => $_->name,
+        note          => $_->note,
+        tags          => [ map { $_->format_name } $_->tags ],
+        requires      => [ map { $_->as_string } $_->requires ],
+        conflicts     => [ map { $_->as_string } $_->conflicts ],
+        planned_at    => $_->timestamp,
+        planner_name  => $_->planner_name,
+        planner_email => $_->planner_email,
+    } ) ] } $plan->changes
+], 'Should have paged all changes';
+
 # Make sure we catch bad format codes.
 isa_ok $cmd = $CLASS->new(
     sqitch => $sqitch,
@@ -646,7 +672,7 @@ $mock_cmd->mock(parse_args => sub {
 });
 $orig_parse = $mock_cmd->original('parse_args');
 
-# Try specifying an unkonwn target.
+# Try specifying an unknown target.
 ok $cmd = $CLASS->new( sqitch => $sqitch, target => 'foo'),
     'Create plan command with unknown target option';
 throws_ok { $cmd->execute } 'App::Sqitch::X',

--- a/t/rework.t
+++ b/t/rework.t
@@ -227,6 +227,9 @@ is_deeply +MockOutput->get_info, [
     ["  * $verify_file"],
 ], 'And the info message should suggest editing the old files';
 is_deeply +MockOutput->get_debug, [
+    ['    ', __x 'Created {file}', file => dir qw(test-rework deploy) ],
+    ['    ', __x 'Created {file}', file => dir qw(test-rework revert) ],
+    ['    ', __x 'Created {file}', file => dir qw(test-rework verify) ],
     [__x(
         'Copied {src} to {dest}',
         dest => $deploy_file2,

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -375,6 +375,15 @@ is_deeply [$snow->_regex_expr('corn', 'Obama$')],
     'Should use regexp_substr IS NOT NULL for regex expr';
 
 ##############################################################################
+# Test unexpeted datbase error in _cid().
+$mock_snow->mock(dbh => sub { die 'OW' });
+throws_ok { $snow->initialized } qr/OW/,
+    'initialized() should rethrow unexpected DB error';
+throws_ok { $snow->_cid } qr/OW/,
+    '_cid should rethrow unexpected DB error';
+$mock_snow->unmock('dbh');
+
+##############################################################################
 # Test _run(), _capture() _spool(), and _probe().
 $config->replace('core.engine' => 'snowflake');
 can_ok $snow, qw(_run _capture _spool);

--- a/t/sqitch.conf
+++ b/t/sqitch.conf
@@ -19,6 +19,7 @@
     dest_dir  = _build/sql
 [foo "BAR"]
 	baz = hello
+    yep
 [guess "Yes.No"]
 	red = true
 	Calico = false

--- a/t/win32.t
+++ b/t/win32.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl -w
+
+# local *main::^O;
+BEGIN {
+    $^O = 'MSWin32';
+}
+
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Try::Tiny;
+use App::Sqitch::ItemFormatter;
+
+is $^O, 'MSWin32', 'Should have "MSWin32"';
+is App::Sqitch::ItemFormatter::CAN_OUTPUT_COLOR,
+    try { require Win32::Console::ANSI },
+    'CAN_OUTPUT_COLOR should be set properly';


### PR DESCRIPTION
Includes a few minor changes to the modules, including:

*   Move duplicate path creation methods from the add and bundle commands to their parent, App::Sqitch::Command.
*   Removed the update_config subroutine from the engine command, which has not been callable since 0.9999 in 2019.
*   Removed duplicate calls to `$plan->position` in the `deploy` method of App::Sqitch::Engine, both because it was silly, and also to make it easier to mock.
*   Fixed the column error-checking function in the SQLite engine.
*   Fixed a regex error in the Firebird engine's column error-checking function.
*   Fixed an error checking the return value of `Win32::GetShortPathName`, which is `undef` for nonexistent files, not simply untrue.
*   Extracted the code to create multiple `IN()` clauses in Oracle to its own function so that it could be properly tested.

Most all other changes were in the test suite, expanding the test coverage to 100% for these classes:

*   App::Sqitch::Engine::sqlite
*   App::Sqitch::Command::engine
*   App::Sqitch::ItemFormatter
*   App::Sqitch::Command::config
*   App::Sqitch::Engine::firebird
*   App::Sqitch::Command::bundle
*   App::Sqitch::Command::add
*   App::Sqitch::Role::DBIEngine
*   App::Sqitch::Command::plan
*   App::Sqitch::Role::TargetConfigCommand
*   App::Sqitch::Engine
*   App::Sqitch::Engine::oracle
*   App::Sqitch::Engine::exasol
*   App::Sqitch::Engine::snowflake
*   App::Sqitch::Command

Most of the test changes are mocks and various setups to get to otherwise previously untested, difficult-to-reach branches, though a few are more substantive and straightforward.

The only other change was to the display names of the Yugabyte and Cockroach test workflows and the removal of out-dated, commented translations from the French localization dictionary.
