### PR TITLE
Explicitly set TZ in tests using local time zone

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Revision history for Perl extension App::Sqitch
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would
        always pass the port to `psql`, thus ignoring the `PGPORT` environment
        variable. Thanks to Cam Feenstra for the spot (#675)!
+     - Fixed test failures on OSes where the local time zone cannot be
+       determined. Thanks to Slaven Rezić for the test reports, and to
+       Dave Rolsky for the solution (#672).
 
 1.3.0  2022-08-12T22:09:13Z
      - Fixed an issue when testing Firebird on a host with Firebird installed

--- a/t/datetime.t
+++ b/t/datetime.t
@@ -15,6 +15,7 @@ use TestConfig;
 
 my $CLASS = 'App::Sqitch::DateTime';
 require_ok $CLASS;
+local $ENV{TZ} = 'America/Vancouver';
 
 ok my $dt = $CLASS->now, 'Construct a datetime object';
 is_deeply [$dt->as_string_formats], [qw(

--- a/t/item_formatter.t
+++ b/t/item_formatter.t
@@ -18,6 +18,7 @@ use MockOutput;
 use TestConfig;
 use LC;
 
+local $ENV{TZ} = 'America/Chicago';
 my $CLASS = 'App::Sqitch::ItemFormatter';
 require_ok $CLASS;
 can_ok $CLASS => qw(

--- a/t/log.t
+++ b/t/log.t
@@ -19,6 +19,7 @@ use MockOutput;
 use TestConfig;
 use LC;
 
+local $ENV{TZ} = 'America/Los_Angeles';
 my $CLASS = 'App::Sqitch::Command::log';
 require_ok $CLASS;
 

--- a/t/plan_cmd.t
+++ b/t/plan_cmd.t
@@ -19,6 +19,7 @@ use MockOutput;
 use TestConfig;
 use LC;
 
+local $ENV{TZ} = 'America/Sao_Paolo';
 my $CLASS = 'App::Sqitch::Command::plan';
 require_ok $CLASS;
 

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -41,6 +41,7 @@ BEGIN {
 # Mock the home directory to prevent reading a user config file.
 my $tmp_dir = dir tempdir CLEANUP => 1;
 local $ENV{HOME} = $tmp_dir->stringify;
+local $ENV{TZ} = 'America/St_Johns';
 
 is_deeply [$CLASS->config_vars], [
     target   => 'any',

--- a/t/status.t
+++ b/t/status.t
@@ -19,6 +19,7 @@ use TestConfig;
 my $CLASS = 'App::Sqitch::Command::status';
 require_ok $CLASS;
 
+local $ENV{TZ} = 'America/Barbados';
 my $config = TestConfig->new(
     'core.engine'  => 'sqlite',
     'core.top_dir' => 'test-status',


### PR DESCRIPTION
To avoid dying on hosts where the local time zone cannot be determined. Resolves #672.