### PR TITLE
Ban backslash in names and slash in tags

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,12 @@ Revision history for Perl extension App::Sqitch
      - Fixed test failures where DBD::Mem was not installed. Likely only
        occurred on some CPAN Testers nodes. Thanks to Slaven Rezić for those
        (#673).
+     - Banned the backslash character (`\`) in change and tag names. It would
+       be ignored on Unix-style systems, but create unexpected subdirectories
+       on Windows systems.
+     - Banned the slash character (`/`) in tag names. They have been allowed
+       in change names to enable script organization, but can wreak havoc
+       when used in tag names. Thanks to @ewie for the report (#680)!
 
 1.3.0  2022-08-12T22:09:13Z
      - Fixed an issue when testing Firebird on a host with Firebird installed

--- a/lib/App/Sqitch/Plan.pm
+++ b/lib/App/Sqitch/Plan.pm
@@ -30,10 +30,12 @@ my $name_re = qr{
            [[:digit:]]+            #         digits
            (?:$|[[:blank:]])       #         eol or blank
        )                           #     ...
-       [^[:blank:]:@#]             #     match a valid character
+       [^[:blank:]:@#\\]           #     match a valid character
     )+                             # ... end non-capturing group
     (?<![$punct])\b                # last character isn't punctuation
 }x;
+
+my $dir_sep_re = qr{/};
 
 my %reserved = map { $_ => undef } qw(ROOT HEAD);
 
@@ -235,8 +237,8 @@ sub _parse {
             my $proj = $+{value};
             $raise_syntax_error->(__x(
                 qq{invalid project name "{project}": project names must not }
-                . 'begin with punctuation, contain "@", ":", "#", or blanks, or end in '
-                . 'punctuation or digits following punctuation',
+                . 'begin with punctuation, contain "@", ":", "#", "\\", or blanks, '
+                . 'or end in punctuation or digits following punctuation',
                 project => $proj,
             )) unless $proj =~ /\A$name_re\z/;
             $pragmas{project} = $proj;
@@ -316,7 +318,7 @@ sub _parse {
         # Raise errors for missing data.
         $raise_syntax_error->(__(
             qq{Invalid name; names must not begin with punctuation, }
-            . 'contain "@", ":", "#", or blanks, or end in punctuation or digits following punctuation',
+            . 'contain "@", ":", "#", "\\", or blanks, or end in punctuation or digits following punctuation',
         )) if !$params{name}
             || (!$params{yr} && $line =~ $ts_re);
 
@@ -352,6 +354,15 @@ sub _parse {
         );
 
         if ($type eq 'tag') {
+            # Faile if contains directory separators
+            if ($params{name} =~ qr/($dir_sep_re)/) {
+                $raise_syntax_error->(__x(
+                    'Tag "{tag}" contains illegal character {sep}',
+                    tag => $params{name},
+                    sep => $1,
+                ));
+            }
+
             # Fail if no changes.
             unless ($prev_change) {
                 $raise_syntax_error->(__x(
@@ -902,21 +913,20 @@ sub _is_valid {
         name => $name,
     ) if $name =~ /^[0-9a-f]{40}/;
 
-    unless ($name =~ /\A$name_re\z/) {
-        if ($type eq 'change') {
-            hurl plan => __x(
-                qq{"{name}" is invalid: changes must not begin with punctuation, }
-                . 'contain "@", ":", "#", or blanks, or end in punctuation or digits following punctuation',
-                name => $name,
-            );
-        } else {
-            hurl plan => __x(
-                qq{"{name}" is invalid: tags must not begin with punctuation, }
-                . 'contain "@", ":", "#", or blanks, or end in punctuation or digits following punctuation',
-                name => $name,
-            );
-        }
+    if ($type eq 'change' && $name !~ /\A$name_re\z/) {
+        hurl plan => __x(
+            qq{"{name}" is invalid: changes must not begin with punctuation, }
+            . 'contain "@", ":", "#", "\\", or blanks, or end in punctuation or digits following punctuation',
+            name => $name,
+        );
+    } elsif ($type eq 'tag' && ($name !~ /\A$name_re\z/ || $name =~ $dir_sep_re)) {
+        hurl plan => __x(
+            qq{"{name}" is invalid: tags must not begin with punctuation, }
+            . 'contain "@", ":", "#", "/", "\\", or blanks, or end in punctuation or digits following punctuation',
+            name => $name,
+        );
     }
+    return 1;
 }
 
 sub write_to {

--- a/lib/sqitchchanges.pod
+++ b/lib/sqitchchanges.pod
@@ -16,8 +16,8 @@ L<C<sqitch log>|sqitch-log>, search the database for the change.
 =head2 Change Names
 
 A change name, such as that passed to L<C<sqitch add>|sqitch-add> and written
-to the plan file has a few limitations on the characters it may contain. The
-same limitations apply to tag names. The rules are:
+to the plan file, has a few limitations on the characters it may contain. The
+rules are:
 
 =over
 
@@ -43,7 +43,8 @@ Must not end in "~", "^", "/", "=", or "%" followed by digits.
 
 =item *
 
-All other characters may be any UTF-8 character other than ":", "@", and "#".
+All other characters may be any UTF-8 character other than ":", "@", "#",
+and "\".
 
 =back
 
@@ -102,11 +103,26 @@ Some examples of invalid names:
 
 =item C<foo:bar>
 
+=item C<foo\bar>
+
 =item C<+foo>
 
 =item C<-foo>
 
 =item C<@foo>
+
+=back
+
+=head2 Tag Names
+
+A tag name, such as that passed to L<C<sqitch tag>|sqitch-tag> and written
+to the plan file, adhere by the same rules as L</Change Names> with one
+additional limitation: tags must not contain a slash character ("/").
+Example valid change name but invalid tag name:
+
+=over
+
+=item C<foo/bar>
 
 =back
 


### PR DESCRIPTION
Slashes have always been allowed in change names, so that people can organize their changes in directories. On all platofmrs, including Windows, Sqitch depends on slashes to determine directory hierarchies.

But they're particularly problematic for tags, which should never create subdirectires the way change names can, and likekly would have caused issues such as reported in #680. Likely people have avoided them in tags for this reason, though it's possible there may be some configurations that have used them successfully. I'm not sure what to do about those situations.

It's possible that by banning backslash in change names that it could break the directory structure used in Windows-only Sqitchc projects, though it never would have worked properly for cross-platform projects. Again, it's possible that some configurations have used backslash in change names, and it probably works well-enough on Unix-based systems, but would break things on Windows.

It just seems safest overall to completely disallow backslashes and to disallow slashes in tag names. Resolves #680.