### PR TITLE
Allow false separators in formatters

### DIFF
--- a/lib/App/Sqitch/ItemFormatter.pm
+++ b/lib/App/Sqitch/ItemFormatter.pm
@@ -128,12 +128,12 @@ has formatter => (
 
                 t => sub {
                     @{ $_[0]->{tags} }
-                        ? ' ' . join $_[1] || ', ' => @{ $_[0]->{tags} }
+                        ? ' ' . join defined $_[1] ? $_[1] : ', ' => @{ $_[0]->{tags} }
                         : '';
                 },
                 T => sub {
                     @{ $_[0]->{tags} }
-                        ? ' (' . join($_[1] || ', ' => @{ $_[0]->{tags} }) . ')'
+                        ? ' (' . join(defined $_[1] ? $_[1] : ', ' => @{ $_[0]->{tags} }) . ')'
                         : '';
                 },
                 v => sub { "\n" },
@@ -168,24 +168,24 @@ has formatter => (
                 },
                 r => sub {
                     @{ $_[0]->{requires} }
-                        ? ' ' . join $_[1] || ', ' => @{ $_[0]->{requires} }
+                        ? ' ' . join defined $_[1] ? $_[1] : ', ' => @{ $_[0]->{requires} }
                         : '';
                 },
                 R => sub {
                     return '' unless @{ $_[0]->{requires} };
                     return __ ('Requires: ') . ' ' . join(
-                        $_[1] || ', ' => @{ $_[0]->{requires} }
+                        defined $_[1] ? $_[1] : ', ' => @{ $_[0]->{requires} }
                     ) . "\n";
                 },
                 x => sub {
                     @{ $_[0]->{conflicts} }
-                        ? ' ' . join $_[1] || ', ' => @{ $_[0]->{conflicts} }
+                        ? ' ' . join defined $_[1] ? $_[1] : ', ' => @{ $_[0]->{conflicts} }
                         : '';
                 },
                 X => sub {
                     return '' unless @{ $_[0]->{conflicts} };
                     return __('Conflicts:') . ' ' . join(
-                        $_[1] || ', ' => @{ $_[0]->{conflicts} }
+                        defined $_[1] ? $_[1] : ', ' => @{ $_[0]->{conflicts} }
                     ) . "\n";
                 },
                 a => sub {

--- a/t/item_formatter.t
+++ b/t/item_formatter.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 158;
+use Test::More tests => 170;
 #use Test::More 'no_plan';
 use App::Sqitch;
 use Locale::TextDomain qw(App-Sqitch);
@@ -129,6 +129,8 @@ for my $spec (
     ['%{|}t', { tags => [] }, '' ],
     ['%{|}t', { tags => ['@foo'] }, ' @foo' ],
     ['%{|}t', { tags => ['@foo', '@bar'] }, ' @foo|@bar' ],
+    ['%{0}t', { tags => ['@foo', '@bar'] }, ' @foo0@bar' ],
+    ['%{}t', { tags => ['@foo', '@bar'] }, ' @foo@bar' ],
 
     ['%T', { tags => [] }, '' ],
     ['%T', { tags => ['@foo'] }, ' (@foo)' ],
@@ -136,6 +138,8 @@ for my $spec (
     ['%{|}T', { tags => [] }, '' ],
     ['%{|}T', { tags => ['@foo'] }, ' (@foo)' ],
     ['%{|}T', { tags => ['@foo', '@bar'] }, ' (@foo|@bar)' ],
+    ['%{0}T', { tags => ['@foo', '@bar'] }, ' (@foo0@bar)' ],
+    ['%{}T', { tags => ['@foo', '@bar'] }, ' (@foo@bar)' ],
 
     ['%r', { requires => [] }, '' ],
     ['%r', { requires => ['foo'] }, ' foo' ],
@@ -143,6 +147,8 @@ for my $spec (
     ['%{|}r', { requires => [] }, '' ],
     ['%{|}r', { requires => ['foo'] }, ' foo' ],
     ['%{|}r', { requires => ['foo', 'bar'] }, ' foo|bar' ],
+    ['%{0}r', { requires => ['foo', 'bar'] }, ' foo0bar' ],
+    ['%{}r', { requires => ['foo', 'bar'] }, ' foobar' ],
 
     ['%R', { requires => [] }, '' ],
     ['%R', { requires => ['foo'] }, __('Requires: ') . " foo\n" ],
@@ -150,6 +156,8 @@ for my $spec (
     ['%{|}R', { requires => [] }, '' ],
     ['%{|}R', { requires => ['foo'] }, __('Requires: ') . " foo\n" ],
     ['%{|}R', { requires => ['foo', 'bar'] }, __('Requires: ') . " foo|bar\n" ],
+    ['%{0}R', { requires => ['foo', 'bar'] }, __('Requires: ') . " foo0bar\n" ],
+    ['%{}R', { requires => ['foo', 'bar'] }, __('Requires: ') . " foobar\n" ],
 
     ['%x', { conflicts => [] }, '' ],
     ['%x', { conflicts => ['foo'] }, ' foo' ],
@@ -157,6 +165,8 @@ for my $spec (
     ['%{|}x', { conflicts => [] }, '' ],
     ['%{|}x', { conflicts => ['foo'] }, ' foo' ],
     ['%{|}x', { conflicts => ['foo', 'bax'] }, ' foo|bax' ],
+    ['%{0}x', { conflicts => ['foo', 'bax'] }, ' foo0bax' ],
+    ['%{}x', { conflicts => ['foo', 'bax'] }, ' foobax' ],
 
     ['%X', { conflicts => [] }, '' ],
     ['%X', { conflicts => ['foo'] }, __('Conflicts:') . " foo\n" ],
@@ -164,6 +174,8 @@ for my $spec (
     ['%{|}X', { conflicts => [] }, '' ],
     ['%{|}X', { conflicts => ['foo'] }, __('Conflicts:') . " foo\n" ],
     ['%{|}X', { conflicts => ['foo', 'bar'] }, __('Conflicts:') . " foo|bar\n" ],
+    ['%{0}X', { conflicts => ['foo', 'bar'] }, __('Conflicts:') . " foo0bar\n" ],
+    ['%{}X', { conflicts => ['foo', 'bar'] }, __('Conflicts:') . " foobar\n" ],
 
     ['%{yellow}C', {}, '' ],
     ['%{:event}C', { event => 'deploy' }, '' ],


### PR DESCRIPTION
Seemingly valid separators like empty string and 0 that evaluate to false result in use of the default separator. Test for defined separator instead of true.

Tests pass before and after this update. Apologies for not including new tests.