### PR TITLE
Refactor revert options

### DIFF
--- a/lib/App/Sqitch/Command/checkout.pm
+++ b/lib/App/Sqitch/Command/checkout.pm
@@ -55,8 +55,6 @@ sub execute {
     my $git    = $self->client;
     my $engine = $target->engine;
     $engine->with_verify( $self->verify );
-    $engine->no_prompt( $self->no_prompt );
-    $engine->prompt_accept( $self->prompt_accept );
     $engine->log_only( $self->log_only );
     $engine->lock_timeout( $self->lock_timeout );
 
@@ -114,7 +112,7 @@ sub execute {
     $engine->set_variables( $self->_collect_revert_vars($target) );
     $engine->plan( $from_plan );
     try {
-        $engine->revert( $last_common_change->id );
+        $engine->revert( $last_common_change->id, ! $self->no_prompt, $self->prompt_accept );
     } catch {
         # Rethrow unknown errors or errors with exitval > 1.
         die $_ if ! eval { $_->isa('App::Sqitch::X') }

--- a/lib/App/Sqitch/Command/rebase.pm
+++ b/lib/App/Sqitch/Command/rebase.pm
@@ -78,15 +78,15 @@ sub execute {
 
     # Now get to work.
     $engine->with_verify( $self->verify );
-    $engine->no_prompt( $self->no_prompt );
-    $engine->prompt_accept( $self->prompt_accept );
     $engine->log_only( $self->log_only );
     $engine->lock_timeout( $self->lock_timeout );
 
     # Revert.
     $engine->set_variables( $self->_collect_revert_vars($target) );
+    die unless defined $self->no_prompt;
+    die unless defined $self->prompt_accept;
     try {
-        $engine->revert( $onto );
+        $engine->revert( $onto, ! ($self->no_prompt), $self->prompt_accept );
     } catch {
         # Rethrow unknown errors or errors with exitval > 1.
         die $_ if ! eval { $_->isa('App::Sqitch::X') }

--- a/lib/App/Sqitch/Command/revert.pm
+++ b/lib/App/Sqitch/Command/revert.pm
@@ -140,12 +140,10 @@ sub execute {
     )) if @{ $changes };
 
     # Now get to work.
-    $engine->no_prompt( $self->no_prompt );
-    $engine->prompt_accept( $self->prompt_accept );
     $engine->log_only( $self->log_only );
     $engine->lock_timeout( $self->lock_timeout );
     $engine->set_variables( $self->_collect_vars($target) );
-    $engine->revert( $change );
+    $engine->revert( $change, ! ($self->no_prompt), $self->prompt_accept );
     return $self;
 }
 

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -67,6 +67,28 @@ has start_at => (
     isa => Str
 );
 
+has no_prompt => (
+    is      => 'rw',
+    isa     => Bool,
+    trigger => sub {
+        # Deprecation notice added Feb 2023
+        warnings::warnif("deprecated",
+                         __("Engine::no_prompt is deprecated and will be removed in a future release\n".
+                            "Use direct arguments to revert() instead"));
+    }
+);
+
+has prompt_accept => (
+    is      => 'rw',
+    isa     => Bool,
+    trigger => sub {
+        # Deprecation notice added Feb 2023
+        warnings::warnif("deprecated",
+                         __("Engine::prompt_accept is deprecated and will be removed in a future release\n".
+                            "Use direct arguments to revert() instead"));
+    }
+);
+
 has log_only => (
     is      => 'rw',
     isa     => Bool,
@@ -257,16 +279,23 @@ sub deploy {
     $self->$meth( $plan, $to_index );
 }
 
-sub revert($$$$) {
+sub revert {
     # $to = revert up to (but not including) this change. May be undefined.
     # $prompt = If true, we ask for confirmation; if false, we don't.
     # $prompt_default = Default if the user just hits enter at the prompt.
     my ( $self, $to, $prompt, $prompt_default ) = @_;
 
     if (defined $prompt) {
-        hurl revert => 'Missing mandatory parameter $prompt_default' unless defined $prompt_default;
+        hurl revert => __('Missing mandatory parameter $prompt_default') unless defined $prompt_default;
     } else {
-        hurl revert => 'Missing mandatory parameter $prompt'
+        warnings::warnif("deprecated",
+                         __("This calling style of Engine::revert is deprecated.\n".
+                            "In the future `prompt` and `prompt_accept` parameters will be mandatory"));
+
+        my $no_prompt = $self->no_prompt // 0;
+        $prompt = ! $no_prompt;
+
+        $prompt_default = $self->prompt_accept // 1;
     }
 
     # Check the registry and, once we know it's there, lock the destination.

--- a/t/checkout.t
+++ b/t/checkout.t
@@ -583,7 +583,7 @@ is_deeply +MockOutput->get_info, [[__x(
 )]], 'Should have emitted info identifying the last common change';
 
 # Did it revert?
-is_deeply \@rev_args, [$checkout->default_target->plan->get('users')->id],
+is_deeply \@rev_args, [$checkout->default_target->plan->get('users')->id, 1, undef],
     '"users" ID and 1 should be passed to the engine revert';
 is_deeply \@rev_changes, [qw(roles users widgets)],
     'Should have had the current changes for revision';

--- a/t/revert.t
+++ b/t/revert.t
@@ -262,18 +262,17 @@ $orig_method = $mock_cmd->original('parse_args');
 
 # Pass the change.
 ok $revert->execute('@alpha'), 'Execute to "@alpha"';
-ok $target->engine->no_prompt, 'Engine should be no_prompt';
 ok !$target->engine->log_only, 'Engine should not be log_only';
 is $target->engine->lock_timeout, App::Sqitch::Engine::default_lock_timeout(),
     'The engine should have the default lock_timeout';
-is_deeply \@args, ['@alpha'],
+is_deeply \@args, ['@alpha', '', undef],
     '"@alpha" should be passed to the engine';
 is_deeply +MockOutput->get_warn, [], 'Should have no warnings';
 
 # Pass nothing.
 @args = ();
 ok $revert->execute, 'Execute';
-is_deeply \@args, [undef],
+is_deeply \@args, [undef, '', undef],
     'undef should be passed to the engine';
 is_deeply {@vars}, { },
     'No vars should have been passed through to the engine';
@@ -281,27 +280,24 @@ is_deeply +MockOutput->get_warn, [], 'Should still have no warnings';
 
 # Pass the target.
 ok $revert->execute('db:sqlite:hi'), 'Execute to target';
-ok $target->engine->no_prompt, 'Engine should be no_prompt';
 ok !$target->engine->log_only, 'Engine should not be log_only';
-is_deeply \@args, [undef],
+is_deeply \@args, [undef, '', undef],
     'undef" should be passed to the engine';
 is $target->name, 'db:sqlite:hi', 'Target name should be as passed';
 is_deeply +MockOutput->get_warn, [], 'Should have no warnings';
 
 # Pass them both!
 ok $revert->execute('db:sqlite:lol', 'widgets'), 'Execute with change and target';
-ok $target->engine->no_prompt, 'Engine should be no_prompt';
 ok !$target->engine->log_only, 'Engine should not be log_only';
-is_deeply \@args, ['widgets'],
+is_deeply \@args, ['widgets', '', undef],
     '"widgets" should be passed to the engine';
 is $target->name, 'db:sqlite:lol', 'Target name should be as passed';
 is_deeply +MockOutput->get_warn, [], 'Should have no warnings';
 
 # And reverse them.
 ok $revert->execute('db:sqlite:lol', 'widgets'), 'Execute with target and change';
-ok $target->engine->no_prompt, 'Engine should be no_prompt';
 ok !$target->engine->log_only, 'Engine should not be log_only';
-is_deeply \@args, ['widgets'],
+is_deeply \@args, ['widgets', '', undef],
     '"widgets" should be passed to the engine';
 is $target->name, 'db:sqlite:lol', 'Target name should be as passed';
 is_deeply +MockOutput->get_warn, [], 'Should have no warnings';
@@ -318,10 +314,9 @@ isa_ok $revert = $CLASS->new(
 
 @args = ();
 ok $revert->execute, 'Execute again';
-ok !$target->engine->no_prompt, 'Engine should not be no_prompt';
 ok $target->engine->log_only, 'Engine should be log_only';
 is $target->engine->lock_timeout, 30, 'The lock timeout should be set to 30';
-is_deeply \@args, ['foo'],
+is_deeply \@args, ['foo', 1, undef],
     '"foo" and 1 should be passed to the engine';
 is_deeply {@vars}, { foo => 'bar', one => 1 },
     'Vars should have been passed through to the engine';
@@ -330,10 +325,9 @@ is_deeply +MockOutput->get_warn, [], 'Should have no warnings';
 
 # Try also passing the target and change.
 ok $revert->execute('db:sqlite:lol', '@alpha'), 'Execute with options and args';
-ok !$target->engine->no_prompt, 'Engine should not be no_prompt';
 ok $target->engine->log_only, 'Engine should be log_only';
 is $target->engine->lock_timeout, 30, 'The lock timeout should be set to 30';
-is_deeply \@args, ['foo'],
+is_deeply \@args, ['foo', 1, undef],
     '"foo" and 1 should be passed to the engine';
 is_deeply {@vars}, { foo => 'bar', one => 1 },
     'Vars should have been passed through to the engine';
@@ -378,6 +372,6 @@ $common_ancestor_id = 42;
 @args = ();
 ok $revert->execute, 'Execute again';
 is $target->name, 'db:sqlite:welp', 'Target name should be from option';
-is_deeply \@args, [$common_ancestor_id], 'the common ancestor id should be passed to the engine revert';
+is_deeply \@args, [$common_ancestor_id, 1, undef], 'the common ancestor id should be passed to the engine revert';
 
 done_testing;


### PR DESCRIPTION
Refactor the way we manage the no_prompt and prompt_accept configuration options.

Specifically change these from being a mutable part of engine state to values passed into the `revert` method directly.

This PR is preparation for addressing some of the ideas in #659.

This is a refactor only, there is no behavior change. However some tests that call directly into particular APIs have been adjusted to use the new APIs.