### PR TITLE
Update checkout & cache actions

### DIFF
--- a/.github/workflows/cockroach.yml
+++ b/.github/workflows/cockroach.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - name: Start CockroachDB
         run: docker run -d -p 26257:26257 cockroachdb/cockroach:latest-v${{ matrix.version }} start-single-node --insecure
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,13 +46,13 @@ jobs:
     steps:
       - name: Start CockroachDB
         run: docker run -d -p 26257:26257 cockroachdb/cockroach:latest start-single-node --insecure
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/exasol.yml
+++ b/.github/workflows/exasol.yml
@@ -20,7 +20,7 @@ jobs:
         ports: [ 8563 ]
         options: --privileged
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Clients
         run: .github/ubuntu/exasol.sh
       - name: Setup Perl
@@ -28,7 +28,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/firebird.yml
+++ b/.github/workflows/firebird.yml
@@ -29,7 +29,7 @@ jobs:
           ISC_PASSWORD: nix
           FIREBIRD_DATABASE: sqitchtest.db
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Clients
         run: .github/ubuntu/firebird.sh
       - name: Setup Perl
@@ -37,7 +37,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -35,7 +35,7 @@ jobs:
         ports: [ 3306 ]
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Clients
         run: .github/ubuntu/mysql.sh
       - name: Setup Perl
@@ -43,7 +43,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -39,7 +39,7 @@ jobs:
           --health-timeout 10s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Clients
         run: .github/ubuntu/oracle.sh
       - name: Setup Perl
@@ -47,7 +47,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -18,14 +18,14 @@ jobs:
     name: ${{ matrix.icon }} ${{ matrix.name }}
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - run: perl -V
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -19,14 +19,14 @@ jobs:
     name: 🧅 Perl ${{ matrix.perl }} on ${{ matrix.os[0] }} ${{ matrix.os[1] }}
     runs-on: ${{ matrix.os[1] }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: "${{ matrix.perl }}" }
       - run: perl -V
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -15,13 +15,13 @@ jobs:
     name: 🐘 Postgres ${{ matrix.pg }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Perl
       id: perl
       uses: shogo82148/actions-setup-perl@v1
       with: { perl-version: latest }
     - name: Cache CPAN Modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: local
         key: perl-${{ steps.perl.outputs.perl-hash }}
@@ -47,7 +47,7 @@ jobs:
         DZIL_CONFIRMRELEASE_DEFAULT: "yes"
       run: |
         local/bin/dzil release
-        echo "::set-output name=tarball::$( ls App-Sqitch-*.tar.gz )"
+        echo "tarball=$( ls App-Sqitch-*.tar.gz )" >> $GITHUB_OUTPUT
     - name: Generate Release Changes
       run: xt/gen_release_changes
     - name: Create GitHub Release

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -11,7 +11,7 @@ jobs:
     name: ❄️ Snowflake
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Clients
         run: .github/ubuntu/snowflake.sh
       - name: Setup Perl
@@ -19,7 +19,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -16,13 +16,13 @@ jobs:
     name: 💡 SQLite ${{ matrix.sqlite }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/vertica.yml
+++ b/.github/workflows/vertica.yml
@@ -28,7 +28,7 @@ jobs:
         image: ${{ matrix.image }}:${{ matrix.version }}
         ports: [ 5433 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Clients
         run: .github/ubuntu/vertica.sh
       - name: Setup Perl
@@ -36,7 +36,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}

--- a/.github/workflows/yugabyte.yml
+++ b/.github/workflows/yugabyte.yml
@@ -24,13 +24,13 @@ jobs:
         uses: yugabyte/yugabyte-db-action@master
         with:
           yb_image_tag: "${{ matrix.tag }}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
         with: { perl-version: latest }
       - name: Cache CPAN Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}


### PR DESCRIPTION
And use the new environment files for setting output for a release tarabll. Done in response to warnings in workflow runs pointing to these anouncements:

  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/