### PR TITLE
Add a new strict-mode configuration option

### DIFF
--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1786,6 +1786,9 @@ B<may be left in a corrupted state>. Write your revert scripts carefully!
 Reverts the L<App::Sqitch::Plan::Tag> from the database, including all of its
 associated changes.
 
+Note that this method does not obey the C<${cmd}.strict> configuration
+option; that should be checked by callers.
+
 =head3 C<verify>
 
   $engine->verify;

--- a/lib/sqitch-checkout.pod
+++ b/lib/sqitch-checkout.pod
@@ -280,6 +280,17 @@ executing the revert should be "yes" or "no". The C<checkout.prompt_accept>
 variable takes precedence over C<revert.prompt_accept>, and both default to
 true, meaning to accept the revert.
 
+=item C<[checkout.strict]>
+
+=item C<[revert.strict]>
+
+A boolean value which, when set to true, completely disables the
+checkout command. The C<checkout.strict> variable takes precedence over
+c<revert.strict>. By default the checkout command is not disabled.
+
+When the checkout command is disabled, use the C<deploy> and C<revert>
+commands directly.
+
 =back
 
 =head1 Sqitch

--- a/lib/sqitch-rebase.pod
+++ b/lib/sqitch-rebase.pod
@@ -317,6 +317,17 @@ executing the revert should be "yes" or "no". The C<rebase.prompt_accept>
 variable takes precedence over C<revert.prompt_accept>, and both default to
 true, meaning to accept the revert by default.
 
+=item C<[rebase.strict]>
+
+=item C<[revert.strict]>
+
+A boolean value which, when set to true, completely disables the
+rebase command. The C<rebase.strict> variable takes precedence over
+c<revert.strict>. By default the rebase command is not disabled.
+
+When the rebase command is disabled, use the C<deploy> and C<revert>
+commands directly.
+
 =back
 
 =head1 Sqitch

--- a/lib/sqitch-revert.pod
+++ b/lib/sqitch-revert.pod
@@ -207,6 +207,12 @@ are merged in the following priority order:
 
 =back
 
+=item C<revert.strict>
+
+When this setting is enabled, it is mandatory to specify a change to
+which the database should be reverted and the default behavior to
+revert all changes is disabled. This setting is disabled by default.
+
 =item C<[revert.no_prompt]>
 
 A boolean value indicating whether or not to disable the prompt before

--- a/t/checkout.t
+++ b/t/checkout.t
@@ -682,4 +682,41 @@ for my $spec (
         "Should rethrow $spec->[0] exception";
 }
 
+
+# Should die if running in strict mode.
+ok $config = TestConfig->new(
+    'revert.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+ok $config = TestConfig->new(
+    'checkout.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+ok $config = TestConfig->new(
+    'revert.strict'    => 1,
+    'checkout.strict'  => 0
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+ok $CLASS->new(
+    sqitch           => $sqitch,
+    ),
+   'Okay to initialize because checkout is not in strict mode';
+
 done_testing;

--- a/t/rebase.t
+++ b/t/rebase.t
@@ -714,4 +714,41 @@ for my $spec (
         "Should rethrow $spec->[0] exception";
 }
 
+# Should die if running in strict mode.
+ok $config = TestConfig->new(
+    'revert.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+ok $config = TestConfig->new(
+    'rebase.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+# rebase.strict overrides revert.strict
+ok $config = TestConfig->new(
+    'revert.strict'    => 1,
+    'rebase.strict'    => 0
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+ok $CLASS->new(
+    sqitch           => $sqitch,
+    ),
+   'Okay to initialize because rebase is not in strict mode';
+
 done_testing;

--- a/t/revert.t
+++ b/t/revert.t
@@ -374,4 +374,21 @@ ok $revert->execute, 'Execute again';
 is $target->name, 'db:sqlite:welp', 'Target name should be from option';
 is_deeply \@args, [$common_ancestor_id, 1, undef], 'the common ancestor id should be passed to the engine revert';
 
+# Test strict mode
+$config = TestConfig->new(
+    'core.engine'    => 'sqlite',
+    'core.top_dir'   => dir(qw(t sql))->stringify,
+    'core.plan_file' => file(qw(t sql sqitch.plan))->stringify,
+    'revert.strict'    => 1
+);
+$sqitch = App::Sqitch->new(config => $config);
+isa_ok $revert = $CLASS->new(
+    sqitch    => $sqitch,
+    target    => 'db:sqlite:welp',
+    no_prompt => 1,
+), $CLASS, 'new revert with target';
+throws_ok { $revert->execute() }
+    'App::Sqitch::X',
+    'In strict mode, cannot revert without a specified change.';
+
 done_testing;


### PR DESCRIPTION
This new configuration option disables some functionality that could be perceived as creating risks to production environments.

To begin with, that includes:

- The checkout and rebase commands
- Running revert without a change specified ("Revert All Changes" function).