### PR TITLE
Warn on sqitch add file with double extension

### DIFF
--- a/lib/App/Sqitch/Command/add.pm
+++ b/lib/App/Sqitch/Command/add.pm
@@ -409,10 +409,10 @@ sub _add {
     );
     
     # Warn if the file name has a double extension
-    if ($file =~ m/\.(\w+)\.\w+$/) {
+    if ($file =~ m/\.(\w+)\.\1+$/) {
         my $ext = $1;
-        $self->warning(__x(
-            'Warning: file {file} has a double extension of {ext}',
+        $self->warn(__x(
+            'File {file} has a double extension of {ext}',
             file => $file,
             ext  => $ext,
         ));

--- a/lib/App/Sqitch/Command/add.pm
+++ b/lib/App/Sqitch/Command/add.pm
@@ -407,6 +407,17 @@ sub _add {
         file  => $file,
         error => $!
     );
+    
+    # Warn if the file name has a double extension
+    if ($file =~ m/\.(\w+)\.\w+$/) {
+        my $ext = $1;
+        $self->warning(__x(
+            'Warning: file {file} has a double extension of {ext}',
+            file => $file,
+            ext  => $ext,
+        ));
+    }
+    
     $self->info(__x 'Created {file}', file => $file);
 }
 

--- a/t/add.t
+++ b/t/add.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 238;
+use Test::More tests => 240;
 #use Test::More 'no_plan';
 use App::Sqitch;
 use App::Sqitch::Target;
@@ -413,14 +413,6 @@ EOF
     is_deeply +MockOutput->get_info, [[__x 'Created {file}', file => $out ]],
         'Info should show $out created';
     unlink $out;
-
-    # # Test with file name having a double extension
-    $out = file 'test-add', 'duplicate_extension_test.sql.sql';
-    warning_is {
-        $add->_add('duplicate_extension_test.sql', $out, $tmpl, 'sqlite', 'add')
-    } [qr/double extension of sql/], 'Should get warning for file name with double extension';
-
-    unlink $out;
     
     # Try with requires and conflicts.
     ok $add =  $CLASS->new(
@@ -448,6 +440,18 @@ BEGIN;
 COMMIT;
 EOF
     unlink $out;
+
+  # Test with file name having a double extension
+  $out = file 'test-add', 'duplicate_extension_test.sql.sql';
+  $add->_add('duplicate_extension_test.sql', $out, $tmpl, 'sqlite', 'add');
+  is_deeply +MockOutput->get_info, [[__x 'Created {file}', file => $out ]],
+      'Info should show $out created';
+  is_deeply +MockOutput->get_warn, [[__x(
+      'File {file} has a double extension of {ext}',
+      file => $out,
+      ext => 'sql',
+  )]], 'Should have warned about double extension';
+  unlink $out;
 };
 
 # First, test  with Template::Tiny.

--- a/t/add.t
+++ b/t/add.t
@@ -414,6 +414,14 @@ EOF
         'Info should show $out created';
     unlink $out;
 
+    # # Test with file name having a double extension
+    $out = file 'test-add', 'duplicate_extension_test.sql.sql';
+    warning_is {
+        $add->_add('duplicate_extension_test.sql', $out, $tmpl, 'sqlite', 'add')
+    } [qr/double extension of sql/], 'Should get warning for file name with double extension';
+
+    unlink $out;
+    
     # Try with requires and conflicts.
     ok $add =  $CLASS->new(
         sqitch    => $sqitch,


### PR DESCRIPTION
- Warn on sqitch add file with double extension: `sqitch add` includes extensions for each engine. Warn if user specifies a filename like `myobjects.sql` resulting in the `myobjects.sql.sql`