### PR TITLE
Refactor strict mode 

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,13 @@ Revision history for Perl extension App::Sqitch
        Thanks to @vectro for the PR (#704).
      - Added a warning for a double extension on the file names created
        by the `add` command. Thanks to @blairjordan for the PR (#724)!
+     - Added the `revert.strict` boolean configuration variable which, when
+       set to true, requires that a change to revert to be specified. It also
+       disables the `rebase` and `checkout` commands, though the
+       `rebase.strict` and `checkout.strict` variables, respectively, may
+       override it. Use this variable to prevent accidental reverts in
+       sensitive environments. Thanks to @vectro for the PR (#719; revised in
+       #735)!
 
 1.3.1  2022-10-01T18:49:30Z
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1786,6 +1786,9 @@ B<may be left in a corrupted state>. Write your revert scripts carefully!
 Reverts the L<App::Sqitch::Plan::Tag> from the database, including all of its
 associated changes.
 
+Note that this method does not obey the C<${cmd}.strict> configuration
+option; that should be checked by callers.
+
 =head3 C<verify>
 
   $engine->verify;

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -1786,8 +1786,8 @@ B<may be left in a corrupted state>. Write your revert scripts carefully!
 Reverts the L<App::Sqitch::Plan::Tag> from the database, including all of its
 associated changes.
 
-Note that this method does not obey the C<${cmd}.strict> configuration
-option; that should be checked by callers.
+Note that this method does not respect the C<$cmd.strict> configuration
+variables, which therefore must be checked by the caller.
 
 =head3 C<verify>
 

--- a/lib/sqitch-checkout.pod
+++ b/lib/sqitch-checkout.pod
@@ -280,6 +280,17 @@ executing the revert should be "yes" or "no". The C<checkout.prompt_accept>
 variable takes precedence over C<revert.prompt_accept>, and both default to
 true, meaning to accept the revert.
 
+=item C<[checkout.strict]>
+
+=item C<[revert.strict]>
+
+A boolean value which, when set to true, completely disables the
+checkout command. The C<checkout.strict> variable takes precedence over
+c<revert.strict>. By default the checkout command is not disabled.
+
+When the checkout command is disabled, use the C<deploy> and C<revert>
+commands directly.
+
 =back
 
 =head1 Sqitch

--- a/lib/sqitch-checkout.pod
+++ b/lib/sqitch-checkout.pod
@@ -284,9 +284,8 @@ true, meaning to accept the revert.
 
 =item C<[revert.strict]>
 
-A boolean value which, when set to true, completely disables the
-checkout command. The C<checkout.strict> variable takes precedence over
-c<revert.strict>. By default the checkout command is not disabled.
+A boolean value that, when true, disables the C<checkout> command. The
+C<checkout.strict> variable takes precedence over C<revert.strict>.
 
 When the checkout command is disabled, use the C<deploy> and C<revert>
 commands directly.

--- a/lib/sqitch-rebase.pod
+++ b/lib/sqitch-rebase.pod
@@ -321,12 +321,8 @@ true, meaning to accept the revert by default.
 
 =item C<[revert.strict]>
 
-A boolean value which, when set to true, completely disables the
-rebase command. The C<rebase.strict> variable takes precedence over
-c<revert.strict>. By default the rebase command is not disabled.
-
-When the rebase command is disabled, use the C<deploy> and C<revert>
-commands directly.
+A boolean value that, when true, disables the C<revert> command. The
+C<revert.strict> variable takes precedence over C<revert.strict>.
 
 =back
 

--- a/lib/sqitch-rebase.pod
+++ b/lib/sqitch-rebase.pod
@@ -317,6 +317,17 @@ executing the revert should be "yes" or "no". The C<rebase.prompt_accept>
 variable takes precedence over C<revert.prompt_accept>, and both default to
 true, meaning to accept the revert by default.
 
+=item C<[rebase.strict]>
+
+=item C<[revert.strict]>
+
+A boolean value which, when set to true, completely disables the
+rebase command. The C<rebase.strict> variable takes precedence over
+c<revert.strict>. By default the rebase command is not disabled.
+
+When the rebase command is disabled, use the C<deploy> and C<revert>
+commands directly.
+
 =back
 
 =head1 Sqitch

--- a/lib/sqitch-revert.pod
+++ b/lib/sqitch-revert.pod
@@ -209,9 +209,8 @@ are merged in the following priority order:
 
 =item C<revert.strict>
 
-When this setting is enabled, it is mandatory to specify a change to
-which the database should be reverted and the default behavior to
-revert all changes is disabled. This setting is disabled by default.
+A boolean value indicating whether or not the change to revert to must
+be specified.
 
 =item C<[revert.no_prompt]>
 

--- a/lib/sqitch-revert.pod
+++ b/lib/sqitch-revert.pod
@@ -207,6 +207,12 @@ are merged in the following priority order:
 
 =back
 
+=item C<revert.strict>
+
+When this setting is enabled, it is mandatory to specify a change to
+which the database should be reverted and the default behavior to
+revert all changes is disabled. This setting is disabled by default.
+
 =item C<[revert.no_prompt]>
 
 A boolean value indicating whether or not to disable the prompt before

--- a/t/check.t
+++ b/t/check.t
@@ -281,7 +281,7 @@ is_deeply +MockOutput->get_warn, [[__x(
 # Make sure we get an exception for unknown args.
 throws_ok { $check->execute(qw(greg)) } 'App::Sqitch::X',
     'Should get an exception for unknown arg';
-is $@->ident, 'check', 'Unknow arg ident should be "check"';
+is $@->ident, 'check', 'Unknown arg ident should be "check"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',
@@ -291,7 +291,7 @@ is $@->message, __nx(
 
 throws_ok { $check->execute(qw(greg jon)) } 'App::Sqitch::X',
     'Should get an exception for unknown args';
-is $@->ident, 'check', 'Unknow args ident should be "check"';
+is $@->ident, 'check', 'Unknown args ident should be "check"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',

--- a/t/checkout.t
+++ b/t/checkout.t
@@ -682,4 +682,41 @@ for my $spec (
         "Should rethrow $spec->[0] exception";
 }
 
+
+# Should die if running in strict mode.
+ok $config = TestConfig->new(
+    'revert.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+ok $config = TestConfig->new(
+    'checkout.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+ok $config = TestConfig->new(
+    'revert.strict'    => 1,
+    'checkout.strict'  => 0
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+ok $CLASS->new(
+    sqitch           => $sqitch,
+    ),
+   'Okay to initialize because checkout is not in strict mode';
+
 done_testing;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -320,7 +320,7 @@ for my $bad (qw(foo bad gar)) {
 # Make sure we get an exception for unknown args.
 throws_ok { $deploy->execute(qw(greg)) } 'App::Sqitch::X',
     'Should get an exception for unknown arg';
-is $@->ident, 'deploy', 'Unknow arg ident should be "deploy"';
+is $@->ident, 'deploy', 'Unknown arg ident should be "deploy"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',
@@ -330,7 +330,7 @@ is $@->message, __nx(
 
 throws_ok { $deploy->execute(qw(greg jon)) } 'App::Sqitch::X',
     'Should get an exception for unknown args';
-is $@->ident, 'deploy', 'Unknow args ident should be "deploy"';
+is $@->ident, 'deploy', 'Unknown args ident should be "deploy"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',

--- a/t/rebase.t
+++ b/t/rebase.t
@@ -714,4 +714,41 @@ for my $spec (
         "Should rethrow $spec->[0] exception";
 }
 
+# Should die if running in strict mode.
+ok $config = TestConfig->new(
+    'revert.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+ok $config = TestConfig->new(
+    'rebase.strict'    => 1
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+throws_ok {
+    $CLASS->new(
+        sqitch           => $sqitch,
+        ); }
+    'App::Sqitch::X',
+    'Cannot initialize command in strict mode.';
+
+# rebase.strict overrides revert.strict
+ok $config = TestConfig->new(
+    'revert.strict'    => 1,
+    'rebase.strict'    => 0
+), 'Create strict config';
+ok $sqitch = App::Sqitch->new(config => $config),
+    'Load a sqitch sqitch object';
+ok $CLASS->new(
+    sqitch           => $sqitch,
+    ),
+   'Okay to initialize because rebase is not in strict mode';
+
 done_testing;

--- a/t/revert.t
+++ b/t/revert.t
@@ -374,4 +374,21 @@ ok $revert->execute, 'Execute again';
 is $target->name, 'db:sqlite:welp', 'Target name should be from option';
 is_deeply \@args, [$common_ancestor_id, 1, undef], 'the common ancestor id should be passed to the engine revert';
 
+# Test strict mode
+$config = TestConfig->new(
+    'core.engine'    => 'sqlite',
+    'core.top_dir'   => dir(qw(t sql))->stringify,
+    'core.plan_file' => file(qw(t sql sqitch.plan))->stringify,
+    'revert.strict'    => 1
+);
+$sqitch = App::Sqitch->new(config => $config);
+isa_ok $revert = $CLASS->new(
+    sqitch    => $sqitch,
+    target    => 'db:sqlite:welp',
+    no_prompt => 1,
+), $CLASS, 'new revert with target';
+throws_ok { $revert->execute() }
+    'App::Sqitch::X',
+    'In strict mode, cannot revert without a specified change.';
+
 done_testing;

--- a/t/revert.t
+++ b/t/revert.t
@@ -343,7 +343,7 @@ is_deeply +MockOutput->get_warn, [[__x(
 # Make sure we get an exception for unknown args.
 throws_ok { $revert->execute(qw(greg)) } 'App::Sqitch::X',
     'Should get an exception for unknown arg';
-is $@->ident, 'revert', 'Unknow arg ident should be "revert"';
+is $@->ident, 'revert', 'Unknown arg ident should be "revert"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',
@@ -353,7 +353,7 @@ is $@->message, __nx(
 
 throws_ok { $revert->execute(qw(greg jon)) } 'App::Sqitch::X',
     'Should get an exception for unknown args';
-is $@->ident, 'revert', 'Unknow args ident should be "revert"';
+is $@->ident, 'revert', 'Unknown args ident should be "revert"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',
@@ -387,8 +387,22 @@ isa_ok $revert = $CLASS->new(
     target    => 'db:sqlite:welp',
     no_prompt => 1,
 ), $CLASS, 'new revert with target';
-throws_ok { $revert->execute() }
+throws_ok { $revert->execute }
     'App::Sqitch::X',
-    'In strict mode, cannot revert without a specified change.';
+    'In strict mode, cannot revert without a specified change';
+is $@->ident, 'revert:strict',
+    'No change in strict mode ident should be "revert:strict"';
+is $@->message, __ 'Must specify a target revision in strict mode',
+    'Should have expected message for no changes in strict mode error';
+
+# Too many targets also fatal in strict mode.
+$ENV{FOO}= 1;
+throws_ok { $revert->execute('@alpha', '@beta') }
+    'App::Sqitch::X',
+    'In strict mode, too many targets is fatal';
+is $@->ident, 'revert:strict',
+    'Too many targets ident should be "revert:strict"';
+is $@->message, __ 'Too many changes specified',
+    'Should have expected message for too many targets error';
 
 done_testing;

--- a/t/verify.t
+++ b/t/verify.t
@@ -281,7 +281,7 @@ is_deeply +MockOutput->get_warn, [[__x(
 # Make sure we get an exception for unknown args.
 throws_ok { $verify->execute(qw(greg)) } 'App::Sqitch::X',
     'Should get an exception for unknown arg';
-is $@->ident, 'verify', 'Unknow arg ident should be "verify"';
+is $@->ident, 'verify', 'Unknown arg ident should be "verify"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',
@@ -291,7 +291,7 @@ is $@->message, __nx(
 
 throws_ok { $verify->execute(qw(greg jon)) } 'App::Sqitch::X',
     'Should get an exception for unknown args';
-is $@->ident, 'verify', 'Unknow args ident should be "verify"';
+is $@->ident, 'verify', 'Unknown args ident should be "verify"';
 is $@->message, __nx(
     'Unknown argument "{arg}"',
     'Unknown arguments: {arg}',


### PR DESCRIPTION
Build on #719. Remove the attribute from RevertDeployCommand and handle it in the configure method. Remove redundant logic from revert.pm. Tweak the docs and remove the incorrect statement that `-y` overrides strict mode. Note the new feature in Changes and credit @vectro. Also fix a few typos in test descriptions.
