### PR TITLE
File name formatting option

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,8 @@ Revision history for Perl extension App::Sqitch
        (libwww-perl/URI#13). Thanks to @bobfang for the report (#744)!
      - Fixed test failures due to a change in the generation of DBI DSN by
        URI::Oracle introduced by libwww-perl/URI-db#23.
+     - Added a format option `%F` to sqitch plan that prints the path of the
+       file used to deploy each migration in the plan.
 
 1.3.1  2022-10-01T18:49:30Z
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would

--- a/lib/App/Sqitch/Command/plan.pm
+++ b/lib/App/Sqitch/Command/plan.pm
@@ -236,6 +236,7 @@ sub execute {
             change_id     => $change->id,
             change        => $change->name,
             note          => $change->note,
+            deploy_file   => $change->deploy_file,
             tags          => [ map { $_->format_name } $change->tags ],
             requires      => [ map { $_->as_string } $change->requires ],
             conflicts     => [ map { $_->as_string } $change->conflicts ],

--- a/lib/App/Sqitch/ItemFormatter.pm
+++ b/lib/App/Sqitch/ItemFormatter.pm
@@ -105,6 +105,7 @@ has formatter => (
                 },
                 n => sub { $_[0]->{change} },
                 o => sub { $_[0]->{project} },
+                F => sub { $_[0]->{deploy_file} },
 
                 c => sub {
                     return "$_[0]->{committer_name} <$_[0]->{committer_email}>"
@@ -439,6 +440,8 @@ The placeholders are:
 =item * C<%n>: Event change name
 
 =item * C<%o>: Event change project name
+
+=item * C<%F>: Deploy file name
 
 =item * C<%($len)h>: abbreviated change of length C<$len>
 

--- a/lib/sqitch-plan.pod
+++ b/lib/sqitch-plan.pod
@@ -294,6 +294,8 @@ The placeholders are:
 
 =item * C<%o>: Event change project name
 
+=item * C<%F>: Deploy file name
+
 =item * C<%($len)h>: abbreviated change of length C<$len>
 
 =item * C<%e>: Event type (deploy, revert, fail)

--- a/t/item_formatter.t
+++ b/t/item_formatter.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 170;
+use Test::More tests => 172;
 #use Test::More 'no_plan';
 use App::Sqitch;
 use Locale::TextDomain qw(App-Sqitch);
@@ -98,6 +98,9 @@ for my $spec (
     ['%n', { change => 'bar' }, 'bar'],
     ['%o', { project => 'foo' }, 'foo'],
     ['%o', { project => 'bar' }, 'bar'],
+
+    ['%F', { deploy_file => 'deploy/change_file.sql' }, 'deploy/change_file.sql'],
+    ['%F', { deploy_file => 'deploy/change_file_with_tag@tag.sql' }, 'deploy/change_file_with_tag@tag.sql'],
 
     ['%c', { committer_name => 'larry', committer_email => 'larry@example.com'  }, 'larry <larry@example.com>'],
     ['%{n}c', { committer_name => 'damian' }, 'damian'],

--- a/t/plan_cmd.t
+++ b/t/plan_cmd.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 232;
+use Test::More tests => 234;
 # use Test::More 'no_plan';
 use App::Sqitch;
 use Locale::TextDomain qw(App-Sqitch);
@@ -313,6 +313,9 @@ for my $spec (
     ['%o', { project => 'foo' }, 'foo'],
     ['%o', { project => 'bar' }, 'bar'],
 
+    ['%F', { deploy_file => 'deploy/change_file.sql' }, 'deploy/change_file.sql'],
+    ['%F', { deploy_file => 'deploy/change_file_with_tag@tag.sql' }, 'deploy/change_file_with_tag@tag.sql'],
+
     ['%p', { planner_name => 'larry', planner_email => 'larry@example.com'  }, 'larry <larry@example.com>'],
     ['%{n}p', { planner_name => 'damian' }, 'damian'],
     ['%{name}p', { planner_name => 'chip' }, 'chip'],
@@ -564,6 +567,7 @@ my $fmt_params = {
     change_id     => $change->id,
     change        => $change->name,
     note          => $change->note,
+    deploy_file   => $change->deploy_file,
     tags          => [ map { $_->format_name } $change->tags ],
     requires      => [ map { $_->as_string } $change->requires ],
     conflicts     => [ map { $_->as_string } $change->conflicts ],
@@ -579,8 +583,6 @@ is_deeply +MockOutput->get_page, [
 ], 'The event should have been paged';
 
 # Set attributes and add more events.
-my $change2 = $plan->change_at(1);
-push @changes => $change, $change2;
 isa_ok $cmd = $CLASS->new(
     sqitch            => $sqitch,
     event             => 'deploy',
@@ -592,7 +594,11 @@ isa_ok $cmd = $CLASS->new(
     reverse           => 1,
     headers           => 0,
 ), $CLASS, 'plan with attributes';
+$plan = $cmd->default_target->plan;
 
+$change = $plan->change_at(0);
+my $change2 = $plan->change_at(1);
+push @changes => $change, $change2;
 ok $cmd->execute, 'Execute plan with attributes';
 is_deeply $search_args, [
     operation => 'deploy',
@@ -609,6 +615,7 @@ my $fmt_params2 = {
     change_id     => $change2->id,
     change        => $change2->name,
     note          => $change2->note,
+    deploy_file   => $change2->deploy_file,
     tags          => [ map { $_->format_name } $change2->tags ],
     requires      => [ map { $_->as_string } $change2->requires ],
     conflicts     => [ map { $_->as_string } $change2->conflicts ],
@@ -626,8 +633,9 @@ is_deeply +MockOutput->get_page, [
 my $cfg = $CLASS->configure( $config, { format => 'raw' } );
 ok $cmd = $CLASS->new( sqitch => $sqitch, %{ $cfg } ),
     'Create command with raw format';
-push @changes => $plan->changes;
+$plan = $cmd->default_target->plan;
 
+push @changes => $plan->changes;
 ok $cmd->execute, 'Execute plan with all changes';
 is_deeply +MockOutput->get_page, [
     ['# ', __x 'Project: {project}', project => $plan->project ],
@@ -639,6 +647,7 @@ is_deeply +MockOutput->get_page, [
         change_id     => $_->id,
         change        => $_->name,
         note          => $_->note,
+        deploy_file   => $_->deploy_file,
         tags          => [ map { $_->format_name } $_->tags ],
         requires      => [ map { $_->as_string } $_->requires ],
         conflicts     => [ map { $_->as_string } $_->conflicts ],
@@ -653,7 +662,9 @@ isa_ok $cmd = $CLASS->new(
     sqitch => $sqitch,
     format => '%Z',
 ), $CLASS, 'plan with bad format';
+$plan = $cmd->default_target->plan;
 
+$change = $plan->change_at(0);
 push @changes, $change;
 throws_ok { $cmd->execute } 'App::Sqitch::X',
     'Should get an exception for a bad format code';


### PR DESCRIPTION
This PR adds a format option %F to sqitch plan that prints the path of the file used to deploy each migration in the plan. The initial use case is to search DB source code in reverse order of deployment. This makes it easy to explore the history of a function or table.

The code prints the full path, including the directory prefix and the .sql suffix, but it's trivial to modify those with an external tool, so we kept the update simple.