### PR TITLE
Use regexes to test database URIs & DSNs

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,10 @@ Revision history for Perl extension App::Sqitch
        override it. Use this variable to prevent accidental reverts in
        sensitive environments. Thanks to @vectro for the PR (#719; revised in
        #735)!
+     - Fixed test failures due to a bug fix in the Perl URI module
+       (libwww-perl/URI#13). Thanks to @bobfang for the report (#744)!
+     - Fixed test failures due to a change in the generation of DBI DSN by
+       URI::Oracle introduced by libwww-perl/URI-db#23.
 
 1.3.1  2022-10-01T18:49:30Z
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -135,14 +135,14 @@ ok $mysql = $CLASS->new(sqitch => $sqitch, target => $target),
 is $mysql->client, '/path/to/mysql', 'client should be as configured';
 is $mysql->uri->as_string, 'db:mysql://me:pwd@foo.com/widgets',
     'URI should be as configured';
-is $mysql->target->name, 'db:mysql://me:@foo.com/widgets',
+like $mysql->target->name, qr{^db:mysql://me:?\@foo\.com/widgets$},
     'target name should be the URI without the password';
-is $mysql->destination, 'db:mysql://me:@foo.com/widgets',
+like $mysql->destination, qr{^db:mysql://me:?\@foo\.com/widgets$},
     'destination should be the URI without the password';
 is $mysql->registry, 'meta', 'registry should be as configured';
 is $mysql->registry_uri->as_string, 'db:mysql://me:pwd@foo.com/meta',
     'Sqitch DB URI should be the same as uri but with DB name "meta"';
-is $mysql->registry_destination, 'db:mysql://me:@foo.com/meta',
+like $mysql->registry_destination, qr{^db:mysql://me:?\@foo\.com/meta$},
     'registry_destination should be the sqitch DB URL without the password';
 is_deeply [$mysql->mysql], [
     '/path/to/mysql',

--- a/t/oracle.t
+++ b/t/oracle.t
@@ -243,7 +243,7 @@ $target = App::Sqitch::Target->new(
     sqitch => $sqitch,
     uri    => URI::db->new('db:oracle:secure_user_tns.tpg'),
 );
-is $target->uri->dbi_dsn, 'dbi:Oracle:secure_user_tns.tpg',
+like $target->uri->dbi_dsn, qr{^dbi:Oracle:(?:service_name=)?secure_user_tns\.tpg$},
     'Database-only URI should produce proper DSN';
 isa_ok $ora = $CLASS->new(
     sqitch => $sqitch,
@@ -263,7 +263,7 @@ $target = App::Sqitch::Target->new(
     sqitch => $sqitch,
     uri    => URI::db->new('db:oracle://:@/wallet_tns_name'),
 );
-is $target->uri->dbi_dsn, 'dbi:Oracle:wallet_tns_name',
+like $target->uri->dbi_dsn, qr{dbi:Oracle:(?:service_name=)?wallet_tns_name$},
     'Database and double-slash URI should produce proper DSN';
 isa_ok $ora = $CLASS->new(
     sqitch => $sqitch,

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -322,8 +322,8 @@ is $snow->registry, 'meta', 'registry should be as configured';
 is $snow->uri->as_string,
     'db:snowflake://fred:hi@foo.snowflakecomputing.com/try?warehouse=foo;role=yup',
     'URI should be as configured with full domain name';
-is $snow->destination,
-    'db:snowflake://fred:@foo.snowflakecomputing.com/try?warehouse=foo;role=yup',
+like $snow->destination,
+    qr{^db:snowflake://fred:?\@foo\.snowflakecomputing\.com/try\?warehouse=foo;role=yup$},
     'Destination should omit password';
 
 is $snow->client, '/path/to/snowsql', 'client should be as configured';

--- a/t/sqlite.t
+++ b/t/sqlite.t
@@ -157,7 +157,7 @@ is $sqlite->destination, 'noext',
     'Destination should be configured target name';
 is $sqlite->registry_uri->as_string, 'db:sqlite://x:foo@/path/to/registry.db',
     'registry_uri should fall back on config wth extension';
-is $sqlite->registry_destination, 'db:sqlite://x:@/path/to/registry.db',
+like $sqlite->registry_destination, qr{^db:sqlite://x:?\@/path/to/registry\.db$},
     'Registry target should be configured registry_uri without password';
 
 # Try a registry with an absolute path.


### PR DESCRIPTION
When there is a username but no password, URI used to leave an orphan colon in the URI (reported in libwww-perl/URI#13). That bug was fixed in libwww-perl/URI#31, leading to failures in Sqitch tests expecting the colon to be present.

libwww-perl/URI-db#23 also changed the DSN of URI::Oracle to specify the database name with `service_name=`.

So change the tests to use regular expressions to match such URIs and DSNs, so that the presence of the colon or service name is optional. Resolves #744.