### PR TITLE
Improve the default client search for sqlplus

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,12 @@ Revision history for Perl extension App::Sqitch
        URI::Oracle introduced by libwww-perl/URI-db#23.
      - Added a format option `%F` to sqitch plan that prints the path of the
        file used to deploy each migration in the plan.
+     - Changed the default location for the Oracle `sqlplus` client when the
+       `ORACLE_HOME` environment variable is set. It now returns either
+       `$ORACLE_HOME/bin/sqlplus` or `$ORACLE_HOME/sqlplus` if it exists
+       and is executable (and ends in `.exe` on Windows). Otherwise it simply
+       returns `sqlplus` as before, assuming it will be found in the path.
+       Thanks to @vectro for the suggestion (#747).
 
 1.3.1  2022-10-01T18:49:30Z
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would

--- a/lib/App/Sqitch/Engine/oracle.pm
+++ b/lib/App/Sqitch/Engine/oracle.pm
@@ -78,7 +78,14 @@ sub driver { 'DBD::Oracle 1.23' }
 sub default_registry { $_[0]->username || '' }
 
 sub default_client {
-    file( ($ENV{ORACLE_HOME} || ()), 'sqlplus' )->stringify
+    if ($ENV{ORACLE_HOME}) {
+        my $bin = 'sqlplus' . (App::Sqitch::ISWIN || $^O eq 'cygwin' ? '.exe' : '');
+        my $path = file $ENV{ORACLE_HOME}, 'bin', $bin;
+        return $path->stringify if -f $path && -x $path;
+        $path = file $ENV{ORACLE_HOME}, $bin;
+        return $path->stringify if -f $path && -x $path;
+    }
+    return 'sqlplus';
 }
 
 has dbh => (

--- a/t/firebird.t
+++ b/t/firebird.t
@@ -369,7 +369,7 @@ DBH: {
         'Should get undef from change_id_for when no useful params';
 }
 
-# Make sure defaul_client croaks when it finds no client.
+# Make sure default_client croaks when it finds no client.
 FSPEC: {
     # Give it an invalid fbsql file to find.
     my $tmpdir = tempdir(CLEANUP => 1);

--- a/t/oracle.t
+++ b/t/oracle.t
@@ -113,6 +113,7 @@ use Try::Tiny;
 use App::Sqitch;
 use App::Sqitch::Target;
 use App::Sqitch::Plan;
+use File::Temp 'tempdir';
 use lib 't/lib';
 use DBIEngineTest;
 use TestConfig;
@@ -142,11 +143,36 @@ is $ora->name, 'Oracle', 'Name should be "Oracle"';
 my $client = 'sqlplus' . (App::Sqitch::ISWIN ? '.exe' : '');
 is $ora->client, $client, 'client should default to sqlplus';
 ORACLE_HOME: {
-    local $ENV{ORACLE_HOME} = '/foo/bar';
+    my $iswin = App::Sqitch::ISWIN || $^O eq 'cygwin';
+    my $cli = 'sqlplus' . ($iswin ? '.exe' : '');
+
+    # Start with no ORACLE_HOME.
     my $target = App::Sqitch::Target->new(sqitch => $sqitch);
     isa_ok my $ora = $CLASS->new(sqitch => $sqitch, target => $target), $CLASS;
-    is $ora->client, Path::Class::file('/foo/bar', $client)->stringify,
-        'client should use $ORACLE_HOME';
+    is $ora->client, $cli, 'client should default to sqlplus';
+
+    # Put client in ORACLE_HOME.
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $tmp = Path::Class::Dir->new("$tmpdir");
+    my $sqlplus = $tmp->file($cli);
+    $sqlplus->touch;
+    chmod '0755', $sqlplus unless $iswin;
+
+    local $ENV{ORACLE_HOME} = "$tmpdir";
+    $target = App::Sqitch::Target->new(sqitch => $sqitch);
+    isa_ok $ora = $CLASS->new(sqitch => $sqitch, target => $target), $CLASS;
+    is $ora->client, $sqlplus, 'client should use $ORACLE_HOME';
+
+    # ORACLE_HOME/bin takes precedence.
+    my $bin = Path::Class::Dir->new("$tmpdir", 'bin');
+    $bin->mkpath;
+    $sqlplus = $bin->file($cli);
+    $sqlplus->touch;
+    chmod '0755', $sqlplus unless $iswin;
+
+    $target = App::Sqitch::Target->new(sqitch => $sqitch);
+    isa_ok $ora = $CLASS->new(sqitch => $sqitch, target => $target), $CLASS;
+    is $ora->client, $sqlplus, 'client should use $ORACLE_HOME/bin';
 }
 
 is $ora->registry, '', 'registry default should be empty';


### PR DESCRIPTION
Some installations of SQL*Plus live in `$ORACLE_HOME/bin` rather than just in `$ORACLE_HOME`. So refine `default_client()` to search for an executable file in `$ORACLE_HOME/bin` and return that value if it exists, then look for an executable file in `$ORACLE_HOME` and return it if it exists. Otherwise simply return `sqlplus`. This changes the previous behavior where it would always return `$ORACLE_HOME/sqlplus` if `$ORACLE_HOME` is set. Now it will fall back on a path search if `sqlplus` isn't in `ORACLE_HOME` even when `ORACLE_HOME` is set. Resolves #747.