### PR TITLE
Smartmatch warnings were moved from 'experimental::smartmatch' to 'deprecated::smartmatch'

### DIFF
--- a/lib/App/Sqitch/ItemFormatter.pm
+++ b/lib/App/Sqitch/ItemFormatter.pm
@@ -51,6 +51,7 @@ has formatter => (
     default => sub {
         my $self = shift;
         no if $] >= 5.017011, warnings => 'experimental::smartmatch';
+        no if $] >= 5.037010, warnings => 'deprecated::smartmatch';
         String::Formatter->new({
             input_processor => 'require_single_input',
             string_replacer => 'method_replace',


### PR DESCRIPTION

In Debian we are currently applying the following patch to
App-Sqitch.
We thought you might be interested in it too.

    Description: Smartmatch warnings were moved from 'experimental::smartmatch' to 'deprecated::smartmatch'
     in perl 5.37.10.
     Suppress the warnings again by also turning off the new category.
     .
     This is only a band-aid, as Smartmatch is going to be removed in 5.42,
     but at least it will avoid test failures in the present.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1040532
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-07-08
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/sqitch/raw/master/debian/patches/deprecated-smartmatch.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
