### PR TITLE
Fix cockroachdb

### DIFF
--- a/lib/App/Sqitch/Command.pm
+++ b/lib/App/Sqitch/Command.pm
@@ -23,6 +23,7 @@ use constant ENGINES => qw(
     vertica
     exasol
     snowflake
+    cockroach
 );
 
 has sqitch => (

--- a/lib/sqitchtutorial.pod
+++ b/lib/sqitchtutorial.pod
@@ -82,7 +82,10 @@ engine, thanks to the C<--engine pg> option, and saved it to the file.
 Furthermore, it wrote a commented-out C<[engine "pg"]> section with all the
 available PostgreSQL engine-specific settings commented out and ready to be
 edited as appropriate. This configuration will also fork for
-L<YugabyteDB|https://www.yugabyte.com/yugabytedb/> and L<CockroachDB|https://www.cockroachlabs.com/product/> databases, too.
+L<YugabyteDB|https://www.yugabyte.com/yugabytedb/> databases, too. For
+L<CockroachDB|https://www.cockroachlabs.com/product/>, use
+C<--engine cockroach>, instead, and replace any instance of C<pg> with
+C<cockroach> in the rest of this document.
 
 By default, Sqitch will read F<sqitch.conf> in the current directory for
 settings. But it will also read F<~/.sqitch/sqitch.conf> for user-specific

--- a/lib/sqitchtutorial.pod
+++ b/lib/sqitchtutorial.pod
@@ -82,10 +82,7 @@ engine, thanks to the C<--engine pg> option, and saved it to the file.
 Furthermore, it wrote a commented-out C<[engine "pg"]> section with all the
 available PostgreSQL engine-specific settings commented out and ready to be
 edited as appropriate. This configuration will also fork for
-L<YugabyteDB|https://www.yugabyte.com/yugabytedb/> databases, too. For
-L<CockroachDB|https://www.cockroachlabs.com/product/>, use
-C<--engine cockroach>, instead, and replace any instance of C<pg> with
-C<cockroach> in the rest of this document.
+L<YugabyteDB|https://www.yugabyte.com/yugabytedb/> and L<CockroachDB|https://www.cockroachlabs.com/product/> databases, too.
 
 By default, Sqitch will read F<sqitch.conf> in the current directory for
 settings. But it will also read F<~/.sqitch/sqitch.conf> for user-specific


### PR DESCRIPTION
Since cockroach is not listed in https://github.com/sqitchers/sqitch/blob/v1.3.1/lib/App/Sqitch/Command.pm#L17, there's no way to specify engine as `cockroach`.