### PR TITLE
Remove remaining uses of the smartmatch operator

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,8 @@ Revision history for Perl extension App::Sqitch
        not added until Vertica 7.2.
      - Increased minimum SQLite versions to 3.8.6, when unique constraint
        enforcement was added.
+     - Removed remaining uses of the smartmatch operator, thus eliminating
+       the Perl 5.38 warnings about its deprecation. (#769)
 
 1.3.1  2022-10-01T18:49:30Z
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would


### PR DESCRIPTION
Most were removed in 2013, but with Perl 5.38 formally deprecating them (and issuing noisy warnings), it seems prudent to simply replace them with more traditional Perl patterns like the ternary operator and regular expressions.