### PR TITLE
Add cockroach to Command's list of engines

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,9 @@ Revision history for Perl extension App::Sqitch
        enforcement was added.
      - Removed remaining uses of the smartmatch operator, thus eliminating
        the Perl 5.38 warnings about its deprecation. (#769)
+     - Added Cockroach to the list of valid engines recognized in command-line
+       arguments (and a test to ensure new engines won't be omitted in the
+       future). Thanks to @NOBLES5E for the spot (#772)!
 
 1.3.1  2022-10-01T18:49:30Z
      - Fixed a bug introduced in v1.3.0 where the Postgres engine would

--- a/lib/App/Sqitch/Command.pm
+++ b/lib/App/Sqitch/Command.pm
@@ -23,6 +23,7 @@ use constant ENGINES => qw(
     vertica
     exasol
     snowflake
+    cockroach
 );
 
 has sqitch => (
@@ -368,6 +369,8 @@ Returns the list of supported engines, currently:
 =item * C<exasol>
 
 =item * C<snowflake>
+
+=item * C<cockroach>
 
 =back
 

--- a/t/command.t
+++ b/t/command.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 use utf8;
-use Test::More tests => 198;
+use Test::More tests => 199;
 #use Test::More 'no_plan';
 use Test::NoWarnings;
 use List::Util qw(first);
@@ -130,6 +130,15 @@ DEBUG: {
     like $debug, qr{^Can't locate App/Sqitch/Command/_nonesuch\.pm in \@INC},
         'Should have sent error to debug';
 }
+
+##############################################################################
+# Test ENGINES.
+my $dir = Path::Class::Dir->new(
+    Path::Class::File->new($INC{"App/Sqitch.pm"})->dir,
+    qw(Sqitch Engine),
+);
+my @exp = sort grep { s/\.pm$// } map { $_->basename } $dir->children;
+is_deeply [sort $CLASS->ENGINES], \@exp, 'ENGINES should include all engines';
 
 ##############################################################################
 # Test load().


### PR DESCRIPTION
The list recognizes engine names on the command-line. Add a test to ensure new engines added in the future won't be omitted. Thanks to @NOBLES5E for the spot!