### PR TITLE
Get the coverage workflow working again

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,9 @@ jobs:
         image: vertica/vertica-ce:latest
         ports: [ 5433 ]
     steps:
+      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+      - name: Free Disk Space
+        run: rm -rf /opt/hostedtoolcache
       - name: Start CockroachDB
         run: docker run -d -p 26257:26257 cockroachdb/cockroach:latest start-single-node --insecure
       - uses: actions/checkout@v3

--- a/.github/workflows/vertica.yml
+++ b/.github/workflows/vertica.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-         - { label: '12.0', version: 12.0.2-0, image: vertica/vertica-ce,     db: VMart }
+         - { label: '12.0', version: 12.0.4-0, image: vertica/vertica-ce,     db: VMart }
          - { label: '11.0', version: 11.1.1-0, image: vertica/vertica-ce,     db: VMart }
          - { label: '10.1', version: 10.1.1-0, image: vertica/vertica-ce,     db: VMart }
          - { label: '9.2',  version: 9.2.1-0,  image: cjonesy/docker-vertica, db: docker }

--- a/t/vertica.t
+++ b/t/vertica.t
@@ -217,7 +217,8 @@ is_deeply \@capture, [$vta->vsql, qw(foo bar baz)],
     'Command should be passed to capture()';
 
 ok $vta->_probe(qw(hi there)), 'Call _probe';
-is_deeply \@probe, [$vta->vsql, qw(hi there)];
+is_deeply \@probe, [$vta->vsql, qw(hi there)],
+    'Should have expected arguments to _probe';
 
 # Without password.
 $target = App::Sqitch::Target->new( sqitch => $sqitch );
@@ -236,8 +237,9 @@ ok $vta->_capture(qw(foo bar baz)), 'Call _capture again';
 is_deeply \@capture, [$vta->vsql, qw(foo bar baz)],
     'Command should be passed to capture() again';
 
-ok $vta->_probe(qw(go there)), 'Call _probe';
-is_deeply \@probe, [$vta->vsql, qw(go there)];
+ok $vta->_probe(qw(go there)), 'Call _probe again';
+is_deeply \@probe, [$vta->vsql, qw(go there)],
+    'Should again have expected arguments to _probe';
 
 ##############################################################################
 # Test file and handle running.


### PR DESCRIPTION
It was failing because all the Docker images were taking up too much disk space (GitHub workers allow 10GB by default). Fix by deleting unused stuff in the image, as suggested in GitHub community discussions.

Also upgrade the Vertica 12 image (done while troubleshooting overall, might as well keep) and add some missing Vertica test descriptions.