### PR TITLE
Fix range of changes printed in `deploy` debug output

### DIFF
--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -270,7 +270,7 @@ sub deploy {
     );
 
     $sqitch->debug(__ "Will deploy the following changes:");
-    foreach my $will_deploy_position ($plan->position .. $to_index) {
+    foreach my $will_deploy_position (($plan->position + 1) .. $to_index) {
         $sqitch->debug($plan->change_at($will_deploy_position)->format_name_with_tags);
     }
 

--- a/t/engine.t
+++ b/t/engine.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 use utf8;
-use Test::More tests => 780;
+use Test::More tests => 781;
 # use Test::More 'no_plan';
 use App::Sqitch;
 use App::Sqitch::Plan;
@@ -1169,6 +1169,7 @@ is_deeply +MockOutput->get_info, [
 ], 'Should have emitted deploy announcement and successes';
 
 # Make sure we can deploy everything by change.
+MockOutput->clear;
 $latest_change_id = undef;
 $plan->reset;
 $plan->add( name => 'lolz', note => 'ha ha' );
@@ -1207,6 +1208,15 @@ is_deeply +MockOutput->get_info_literal, [
     ['  + widgets @beta ..', '', ' '],
     ['  + lolz ..', '.........', ' '],
 ], 'Should have seen the output of the deploy to the end';
+
+is_deeply +MockOutput->get_debug, [
+    [__ 'Will deploy the following changes:' ],
+    ['roles'],
+    ['users @alpha'],
+    ['widgets @beta'],
+    ['lolz'],
+], 'Debug output should show what will be deployed';
+
 
 # If we deploy again, it should be up-to-date.
 $latest_change_id = $changes[-1]->id;


### PR DESCRIPTION
The debug output of deploy (added with commit 06daffc4) starts with the currently deployed change or the last planned change if nothing is deployed yet.  Fix this by starting with the first change after the current plan position.

Fixes #786.