### PR TITLE
Require Test::Warn 0.31

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,9 @@ Revision history for Perl extension App::Sqitch
        (#795)!
      - Fixed Oracle and Firebird test failures due to incorrect use of `chmod`.
        Thanks to Slaven Rezić for the report and the fix (#807)!
+     - Tests now require Test::Warn 0.31 or later, as newline handling issues
+       cause test failures in earlier versions. Thanks to Slaven Rezić for the
+       test reports and identifying the issue.
 
 1.4.0 2023-08-01T23:37:30Z
      - Fixed Snowflake warehouse and role setup to properly quote identifiers

--- a/t/engine.t
+++ b/t/engine.t
@@ -14,7 +14,7 @@ use Test::Exception;
 use Test::NoWarnings;
 use Test::MockModule;
 use Test::MockObject::Extends;
-use Test::Warn qw(warning_is);
+use Test::Warn 0.31 qw(warning_is);
 use Time::HiRes qw(sleep);
 use Locale::TextDomain qw(App-Sqitch);
 use App::Sqitch::X qw(hurl);
@@ -1938,6 +1938,8 @@ is_deeply $engine->seen, [
 is_deeply +MockOutput->get_info, [], 'Nothing should have been output';
 
 # Make sure deprecation warning happens.
+# Test only the first line of the warning. Reason:
+# https://github.com/hanfried/test-warn/issues/9
 warning_is { $engine->revert }
     "Engine::revert() requires the `prompt` and `prompt_default` arguments.\n",
     'Should get warning omitting required arguments';


### PR DESCRIPTION
Otherwise it chokes on a newline in the message. Also document that we're only testing the first line of a multi-line warning, due to a long-standing bug in Test::Warn.