### PR TITLE
Properly avoid advisory Yugabyte lock errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,13 @@ Revision history for Perl extension App::Sqitch
        exception objects rather than strings, for more consistent error
        handling throughout.
      - Removed duplicate DBI error handling code from engines and tests.
+     - Fixed an order of operation issue that prevented Sqitch from detecting
+       Yugabyte before attempting to create an advisory lock, which results in
+       an error for more recent Yugabyte releases. Thanks to Stefano Ricciardi
+       for the report (#841).
+     - Removed a wayward mention of the long-deprecated `SQITCH_URI`
+       environment variable from the Oracle tutorial. Thanks to Austin Hanson
+       for the report (#845).
 
 1.4.1  2024-02-04T16:35:32Z
      - Removed the quoting of the role and warehouse identifiers that was

--- a/lib/sqitchtutorial-oracle.pod
+++ b/lib/sqitchtutorial-oracle.pod
@@ -306,10 +306,10 @@ using the Docker or VM environments described above, you might need to
 L<create the database|https://docs.oracle.com/cd/B28359_01/server.111/b28310/create001.htm#ADMIN11068>
 and configure the SID. Assuming you have an Oracle SID named C<FLIPR_TEST> set
 up in your C<F<TNSNAMES.ORA>|https://www.orafaq.com/wiki/Tnsnames.ora> file,
-tell Sqitch where to send the change via a
+tell Sqitch where to send the change to a target specified as a
 L<database URI|https://github.com/libwww-perl/uri-db/>, such as
 
-  export SQITCH_URI=db:oracle://$username:$password@/flipr_test
+  export SQITCH_TARGET=db:oracle://$username:$password@/flipr_test
 
 With that URI set up, we can deploy:
 


### PR DESCRIPTION
The `try_lock` method was not properly checking for Yugabyte before attempting to acquire an advisory lock. Likely it used to be a warning, but now is an error that cannot be avoided. So have `try_lock` check for Yugabyte before attempting to take an advisory lock. This requires fetching the database handle, first, as the database is not identified until it connects. So abstract that need by replacing the `_provider` attribute with a method that checks a DBI private module attribute. Fixes #841.

While at it, replace a wayward mention of the long-unsupported (or maybe incorrectly documented?) `SQITCH_URI` environment variable in the Oracle tutorial with the correct name, `SQITCH_TARGET`. Resolves #845.
