### PR TITLE
Omit MySQL checkit() when it cannot be created

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ Revision history for Perl extension App::Sqitch
      - Fixed a bug where the MySQL engine failed to properly handle target
        URIs with no database name. Thanks to Felix Zedén Yverås for the report
        (#821).
+     - Updated the MySQL engine to omit the `checkit()` function when using
+       binary logging and Sqitch lacks super user permissions. Thanks to Scott
+       Edwards for the report and to Janosch Peters for the solution (#824).
 
 1.4.1  2024-02-04T16:35:32Z
      - Removed the quoting of the role and warehouse identifiers that was

--- a/etc/tools/upgrade-registry-to-mysql-5.5.0.sql
+++ b/etc/tools/upgrade-registry-to-mysql-5.5.0.sql
@@ -3,7 +3,8 @@
 -- it to emulate CHECK constraints. It will then also be available for use in
 -- verify scripts, as described in sqitchtutorial-mysql. If you have an
 -- existing Sqitch registry that was upgraded from an earlier version of MySQL
--- to 5.5.0 or higher, you'll need to run this script to update it, like so:
+-- to 5.5.0 or higher, you'll need to run this script as a super user to
+-- update it, like so:
 
 --      mysql -u root sqitch --execute "source `sqitch --etc`/tools/upgrade-registry-to-mysql-5.5.0.sql'
 
@@ -20,23 +21,21 @@ END;
 
 CREATE TRIGGER ck_insert_dependency BEFORE INSERT ON dependencies
 FOR EACH ROW BEGIN
-    -- DO does not work. https://bugs.mysql.com/bug.php?id=69647
-    SET @dummy := checkit(
-            (NEW.type = 'require'  AND NEW.dependency_id IS NOT NULL)
-         OR (NEW.type = 'conflict' AND NEW.dependency_id IS NULL),
-        'Type must be "require" with dependency_id set or "conflict" with dependency_id not set'
-    );
+    IF (NEW.type = 'require' AND NEW.dependency_id IS NULL)
+    OR (NEW.type = 'conflict' AND NEW.dependency_id IS NOT NULL)
+    THEN
+        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = 'Type must be "require" with dependency_id set or "conflict" with dependency_id not set';
+    END IF;
 END;
 |
 
 CREATE TRIGGER ck_update_dependency BEFORE UPDATE ON dependencies
 FOR EACH ROW BEGIN
-    -- DO does not work. https://bugs.mysql.com/bug.php?id=69647
-    SET @dummy := checkit(
-            (NEW.type = 'require'  AND NEW.dependency_id IS NOT NULL)
-         OR (NEW.type = 'conflict' AND NEW.dependency_id IS NULL),
-        'Type must be "require" with dependency_id set or "conflict" with dependency_id not set'
-    );
+    IF (NEW.type = 'require'  AND NEW.dependency_id IS NULL)
+    OR (NEW.type = 'conflict' AND NEW.dependency_id IS NOT NULL)
+    THEN
+        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = 'Type must be "require" with dependency_id set or "conflict" with dependency_id not set';
+    END IF;
 END;
 |
 

--- a/lib/sqitchtutorial-mysql.pod
+++ b/lib/sqitchtutorial-mysql.pod
@@ -228,7 +228,7 @@ Here's where the C<verify> script comes in. Its job is to test that the deploy
 did was it was supposed to. It should do so without regard to any data that
 might be in the database, and should throw an error if the deploy was not
 successful. The simplest way to see if a user exists is to check the
-C<mysql.user> table. However, throwing an error in the event that the user
+C<mysql.user> table.However, throwing an error in the event that the user
 does not exist is tricky in MySQL. To simplify things, on MySQL 5.5.0 and
 higher, Sqitch provides a custom function you can use in your tests,
 C<checkit()>. It works kind of like a C<CHECK> constraint in other databases:
@@ -244,6 +244,19 @@ Give it a try. Put this query into F<verify/appuser.sql>:
 This will work well as long as we know that the registry database is named
 C<sqitch>. If you've set C<engine.mysql.registry> to a different value, you
 will need to make sure you specify the correct database name in the script.
+
+In some configurations, Sqitch does not include C<checkit()>. You can add it
+by connecting to the sqitch registry database as a super user and running:
+
+  DELIMITER |
+  CREATE FUNCTION checkit(doit INTEGER, message VARCHAR(256)) RETURNS INTEGER DETERMINISTIC
+  BEGIN
+      IF doit IS NULL OR doit = 0 THEN
+          SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = message;
+      END IF;
+      RETURN doit;
+  END;
+  |
 
 Now you can run the C<verify> script with the L<C<verify>|sqitch-verify>
 command:

--- a/t/lib/upgradable_registries/mysql.sql
+++ b/t/lib/upgradable_registries/mysql.sql
@@ -152,6 +152,7 @@ CREATE TABLE events (
 
 DELIMITER |
 
+-- ## BEGIN checkit
 CREATE FUNCTION checkit(doit INTEGER, message VARCHAR(256)) RETURNS INTEGER DETERMINISTIC
 BEGIN
     IF doit IS NULL OR doit = 0 THEN
@@ -160,26 +161,25 @@ BEGIN
     RETURN doit;
 END;
 |
+-- ## END checkit
 
 CREATE TRIGGER ck_insert_dependency BEFORE INSERT ON dependencies
 FOR EACH ROW BEGIN
-    -- DO does not work. https://bugs.mysql.com/bug.php?id=69647
-    SET @dummy := checkit(
-            (NEW.type = 'require'  AND NEW.dependency_id IS NOT NULL)
-         OR (NEW.type = 'conflict' AND NEW.dependency_id IS NULL),
-        'Type must be "require" with dependency_id set or "conflict" with dependency_id not set'
-    );
+    IF (NEW.type = 'require' AND NEW.dependency_id IS NULL)
+    OR (NEW.type = 'conflict' AND NEW.dependency_id IS NOT NULL)
+    THEN
+        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = 'Type must be "require" with dependency_id set or "conflict" with dependency_id not set';
+    END IF;
 END;
 |
 
 CREATE TRIGGER ck_update_dependency BEFORE UPDATE ON dependencies
 FOR EACH ROW BEGIN
-    -- DO does not work. https://bugs.mysql.com/bug.php?id=69647
-    SET @dummy := checkit(
-            (NEW.type = 'require'  AND NEW.dependency_id IS NOT NULL)
-         OR (NEW.type = 'conflict' AND NEW.dependency_id IS NULL),
-        'Type must be "require" with dependency_id set or "conflict" with dependency_id not set'
-    );
+    IF (NEW.type = 'require'  AND NEW.dependency_id IS NULL)
+    OR (NEW.type = 'conflict' AND NEW.dependency_id IS NOT NULL)
+    THEN
+        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = 'Type must be "require" with dependency_id set or "conflict" with dependency_id not set';
+    END IF;
 END;
 |
 

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -517,6 +517,7 @@ UPGRADE: {
     my $version = 50500;
     $mock->mock(_fractional_seconds => sub { $fracsec });
     $mock->mock(dbh => sub { { mysql_serverversion => $version } });
+    $mock->mock(_can_create_immutable_function => 1);
 
     # Mock run.
     my @run;


### PR DESCRIPTION
Remove the use of the `checkit()` function from the MySQL triggers that enforce constraints on the `dependencies` table, then modify the deployment of MySQL registry scripts to remove `checkit()` when MySQL is using binary logging and Sqitch is not a super user. Fixes #824, which reports that MySQL with binary logging enabled disallows the creation of `DETERMINISTIC` functions by non-super users. In such a configuration, Sqitch itself functions exactly as before, but `checkit()` is not available for use in verify scripts.

Refactor the MySQL engine's `run_upgrade()` method to move the rejiggering of a file to a new method, `_prepare_registry_file`. Teach that method then to remove bits of the script as appropriate to the MySQL version and permissions.

Update the MySQL tutorial to note how to add `checkit()` if it's missing.