### PR TITLE
Skip registry creation on Snowflake when necessary

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,10 @@ Revision history for Perl extension App::Sqitch
      - Updated the MySQL engine to omit the `checkit()` function when using
        binary logging and Sqitch lacks super user permissions. Thanks to Scott
        Edwards for the report and to Janosch Peters for the solution (#824).
+     - Taught the Snowflake engine to detect when the Sqitch user lacks
+       permission to create a schema and to skip the creation of the registry
+       schema. Useful for cases when the registry schema was created in
+       advance. Thanks to Peter Wimsey for the suggestion (#826).
 
 1.4.1  2024-02-04T16:35:32Z
      - Removed the quoting of the role and warehouse identifiers that was


### PR DESCRIPTION
In some cases, the Sqitch user will lack permission to create a schema, such as when the DBA doesn't want to give it that permission. Implement `run_upgrade` in the Snowflake engine to detect this lack of permission by executing `CREATE SCHEMA IF NOT EXISTS` and stripping out `CREATE SCHEMA` and `COMMENT ON SCHEMA` commands when it fails due to insufficient privileges. Resolves #828.