### PR TITLE
Configure the OS workflow to run monthly

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches: ['*']
   pull_request:
+  schedule:
+    - cron:  '0 14 2 * *' # Monthly at 2pm on the second
 jobs:
   OS:
     strategy:


### PR DESCRIPTION
Add a schedule to run it on the second of each month. Will help to make sure the basics continue to work as dependencies and whatnot change.