### PR TITLE
Update libintl and fix Exasol and Firebird test errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Perl extension App::Sqitch
      - Fixed a bug introduced in v1.5.0 where the MySQL engine connected to
        the target database instead of the registry database. Thanks to
        @tiberiusferreira for the report (#862)!
+     - Fixed test failures with some Exasol and Firebird configurations.
+       Thanks to Slaven Rezić for the report (#858)!
 
 1.5.0  2025-01-08T03:22:40
      - Fix improperly nested Pod headers that were incrementing two levels

--- a/t/exasol.t
+++ b/t/exasol.t
@@ -414,7 +414,7 @@ END {
 $uri = URI->new(
     $ENV{SQITCH_TEST_EXASOL_URI} ||
     $ENV{EXA_URI} ||
-    'db:dbadmin:password@localhost/dbadmin'
+    'db:exasol://dbadmin:password@localhost/dbadmin'
 );
 my $err;
 for my $i (1..30) {

--- a/t/firebird.t
+++ b/t/firebird.t
@@ -31,7 +31,7 @@ my $uri;
 my $tmpdir;
 my $have_fb_driver = 1; # assume DBD::Firebird is installed and so is Firebird
 
-# Is DBD::Firebird realy installed?
+# Is DBD::Firebird really installed?
 try { require DBD::Firebird; } catch { $have_fb_driver = 0; };
 
 BEGIN {
@@ -472,11 +472,13 @@ DBIEngineTest->run(
         # DBD::Firebird.
         my $cmd = $self->client;
         my $cmd_echo = qx(echo "quit;" | "$cmd" -z -quiet 2>&1 );
-        return 0 unless $cmd_echo =~ m{Firebird}ims;
+        App::Sqitch::X::hurl('isql not for Firebird')
+             unless $cmd_echo =~ m{Firebird}ims;
         chomp $cmd_echo;
         say "# Detected $cmd_echo";
         # Skip if no DBD::Firebird.
-        return 0 unless $have_fb_driver;
+        App::Sqitch::X::hurl('DBD::Firebird did not load')
+            unless $have_fb_driver;
         say "# Connected to Firebird $fb_version" if $fb_version;
         return 1;
     },

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -88,7 +88,7 @@ sub run {
         );
         if (my $code = $p{skip_unless}) {
             try {
-                $code->( $engine ) || die 'NO';
+                $code->( $engine ) || App::Sqitch::X::hurl('NO');
             } catch {
                 plan skip_all => sprintf(
                     'Unable to live-test %s engine: %s',

--- a/t/lib/TestConfig.pm
+++ b/t/lib/TestConfig.pm
@@ -8,7 +8,7 @@ BEGIN {
     # Suppress warnings from Locale::Messages.
     # https://github.com/gflohr/libintl-perl/issues/14
     use Locale::Messages;
-    if ($Locale::Messages::package eq 'gettext_pp') {
+    if ($Locale::Messages::package eq 'gettext_pp' && Locale::Messages->VERSION < 1.35) {
         no warnings qw(redefine prototype);
         no strict 'refs';
         my $orig = \&Locale::gettext_pp::__locale_category;

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -578,7 +578,7 @@ $uri = URI->new(
     $ENV{SNOWSQL_URI} ||
     'db:snowflake://accountname/?Driver=Snowflake'
 );
-$uri->host($uri->host . ".snowflakecomputing.com") if $uri->host !~ /snoflakecomputing[.]com/;
+$uri->host($uri->host . ".snowflakecomputing.com") if $uri->host !~ /snowflakecomputing[.]com/;
 my $err = try {
     $snow->use_driver;
     $dbh = DBI->connect($uri->dbi_dsn, $uri->user, $uri->password, {


### PR DESCRIPTION
Check libintl version before suppressing warnings. The warning was fixed in v1.35, so only suppress it ourselves for earlier versions.

Plug a few more holes in the expectation that Sqitch always raises App::Sqitch::X objects rather than strings, as discovered by some unanticipated test configurations (resolves #858). Also fix a couple of typos and the default URI for Exasol tests.