### PR TITLE
Restore MySQL connection to the registry

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Perl extension App::Sqitch
 
-1.5.1  Note yet released
+1.5.1  Not yet released
+     - Fixed a bug introduced in v1.5.0 where the MySQL engine connected to
+       the target database instead of the registry database. Thanks to
+       @tiberiusferreira for the report (#862)!
 
 1.5.0  2025-01-08T03:22:40
      - Fix improperly nested Pod headers that were incrementing two levels

--- a/lib/App/Sqitch/Engine/mysql.pm
+++ b/lib/App/Sqitch/Engine/mysql.pm
@@ -65,7 +65,7 @@ sub _def_user { $_[0]->_mycnf->{user} || $_[0]->sqitch->sysuser }
 sub _def_pass { $ENV{MYSQL_PWD} || shift->_mycnf->{password} }
 
 sub _dsn {
-    (my $dsn = shift->uri->dbi_dsn) =~ s/\Adbi:mysql/dbi:MariaDB/;
+    (my $dsn = shift->registry_uri->dbi_dsn) =~ s/\Adbi:mysql/dbi:MariaDB/;
     return $dsn;
 }
 

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -62,7 +62,7 @@ my $sqitch_uri = $uri->clone;
 $sqitch_uri->dbname('sqitch');
 is $mysql->registry_uri, $sqitch_uri, 'registry_uri should be correct';
 is $mysql->uri, $uri, qq{uri should be "$uri"};
-is $mysql->_dsn, 'dbi:MariaDB:database=mydb', 'DSN should use MariaDB';
+is $mysql->_dsn, 'dbi:MariaDB:database=sqitch', 'DSN should use MariaDB';
 is $mysql->registry_destination, 'db:mysql:sqitch',
     'registry_destination should be the same as registry_uri';
 is $mysql->_lock_name, 'sqitch working on ' . $uri->dbname,


### PR DESCRIPTION
A bug introduced in d17dff9 and shipped in v1.5.0 caused the MySQL engine to connect to the target database instead of the registry database. Restore connecting to the registry database. Resolves #862.