### PR TITLE
Extract checkit function from mysql.sql

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,11 @@ Revision history for Perl extension App::Sqitch
      - Fixed bug where the location of reworked script files did not respect
        the `deploy_dir`, `revert_dir`, or `verify_dir` options. Thanks to Neil
        Freeman for the report (#875)!
+     - Updated the MySQL engine's installation of the `checkit()` function so
+       that it no longer depends on permission-checking, since the current
+       user may not have such permission, and instead attempts to create the
+       function and ignores a failure due to a lack of permission. Thanks to
+       Alastair Douglas for the report and solution (#874)!
 
 1.5.1  2025-03-16T26:55:17Z
      - Fixed a bug introduced in v1.5.0 where the MySQL engine connected to

--- a/etc/tools/upgrade-registry-to-mysql-5.5.0.sql
+++ b/etc/tools/upgrade-registry-to-mysql-5.5.0.sql
@@ -1,24 +1,12 @@
 -- This script upgrades the Sqitch registry for MySQL 5.5.0 and higher. It
--- creates the checkit() function and sets up triggers in the registry to use
--- it to emulate CHECK constraints. It will then also be available for use in
--- verify scripts, as described in sqitchtutorial-mysql. If you have an
--- existing Sqitch registry that was upgraded from an earlier version of MySQL
--- to 5.5.0 or higher, you'll need to run this script as a super user to
--- update it, like so:
+-- sets up triggers in the registry to use it to emulate CHECK constraints. If
+-- you have an existing Sqitch registry that was upgraded from an earlier
+-- version of MySQL to 5.5.0 or higher, you'll need to run this script as a
+-- super user to update it, like so:
 
 --      mysql -u root sqitch --execute "source `sqitch --etc`/tools/upgrade-registry-to-mysql-5.5.0.sql'
 
 DELIMITER |
-
-CREATE FUNCTION checkit(doit INTEGER, message VARCHAR(256)) RETURNS INTEGER DETERMINISTIC
-BEGIN
-    IF doit IS NULL OR doit = 0 THEN
-        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = message;
-    END IF;
-    RETURN doit;
-END;
-|
-
 CREATE TRIGGER ck_insert_dependency BEFORE INSERT ON dependencies
 FOR EACH ROW BEGIN
     IF (NEW.type = 'require' AND NEW.dependency_id IS NULL)

--- a/lib/App/Sqitch/Engine/mysql.sql
+++ b/lib/App/Sqitch/Engine/mysql.sql
@@ -147,24 +147,7 @@ CREATE TABLE events (
 ;
 
 -- ## BEGIN 5.5
--- MySQL does not support checks, so we kind of create our own. The checkit()
--- function works sort of like a CHECK: if the first argument is 0 or NULL, it
--- throws the second argument as an exception. Conveniently, verify scripts
--- can also use it to ensure an error is thrown when a change cannot be
--- verified. Requires MySQL 5.5.0.
-
 DELIMITER |
-
--- ## BEGIN checkit
-CREATE FUNCTION checkit(doit INTEGER, message VARCHAR(256)) RETURNS INTEGER DETERMINISTIC
-BEGIN
-    IF doit IS NULL OR doit = 0 THEN
-        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = message;
-    END IF;
-    RETURN doit;
-END;
-|
--- ## END checkit
 
 CREATE TRIGGER ck_insert_dependency BEFORE INSERT ON dependencies
 FOR EACH ROW BEGIN

--- a/t/lib/upgradable_registries/mysql.sql
+++ b/t/lib/upgradable_registries/mysql.sql
@@ -144,25 +144,9 @@ CREATE TABLE events (
 ;
 
 -- ## BEGIN 5.5
--- MySQL does not support checks, so we kind of create our own. The checkit()
--- function works sort of like a CHECK: if the first argument is 0 or NULL, it
--- throws the second argument as an exception. Conveniently, verify scripts
--- can also use it to ensure an error is thrown when a change cannot be
--- verified. Requires MySQL 5.5.0.
+-- MySQL does not support checks, so we kind of create our own.
 
 DELIMITER |
-
--- ## BEGIN checkit
-CREATE FUNCTION checkit(doit INTEGER, message VARCHAR(256)) RETURNS INTEGER DETERMINISTIC
-BEGIN
-    IF doit IS NULL OR doit = 0 THEN
-        SIGNAL SQLSTATE 'ERR0R' SET MESSAGE_TEXT = message;
-    END IF;
-    RETURN doit;
-END;
-|
--- ## END checkit
-
 CREATE TRIGGER ck_insert_dependency BEFORE INSERT ON dependencies
 FOR EACH ROW BEGIN
     IF (NEW.type = 'require' AND NEW.dependency_id IS NULL)

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -444,7 +444,7 @@ is_deeply [$mysql->_regex_expr('corn', 'Obama$')],
     'Should use REGEXP for regex expr';
 
 ##############################################################################
-# Test unexpeted datbase error in initialized() and _cid().
+# Test unexpected database error in initialized() and _cid().
 MOCKDBH: {
     my $mock = Test::MockModule->new($CLASS);
     $mock->mock(dbh => sub { die 'OW' });
@@ -518,7 +518,7 @@ UPGRADE: {
     my $version = 50500;
     $mock->mock(_fractional_seconds => sub { $fracsec });
     $mock->mock(dbh => sub { { mariadb_serverversion => $version } });
-    $mock->mock(_can_create_immutable_function => 1);
+    $mock->mock(_create_check_function => 1);
 
     # Mock run.
     my @run;
@@ -574,6 +574,51 @@ UPGRADE: {
     file_contents_unlike $tmp_fh, qr/-- ## END 5\.5/,
         'Should have removed MySQL 5.5-requiring block END';
 
+    $mock_sqitch->unmock_all;
+}
+
+##############################################################################
+# Test _create_check_function
+CHECKIT: {
+    {
+        package Test::Mock::Driver;
+        sub do {
+            my $self = shift;
+            $self->{query} = shift;
+            die $self->{err} if $self->{err};
+        }
+    }
+    my $dbh = bless {mariadb_serverversion => 50400}, 'Test::Mock::Driver';
+
+    my $mock = Test::MockModule->new($CLASS);
+    my $warning;
+    $mock_sqitch->mock(warn => sub { shift; $warning = [@_] });
+    
+    $mock->mock(dbh => $dbh);
+    $mysql->_create_check_function;
+    is $dbh->{query}, undef, 'Should have no query';
+    is $warning, undef, 'Should have no warning';
+    
+    $dbh->{mariadb_serverversion} = 50500;
+    $mysql->_create_check_function;
+    like delete $dbh->{query}, qr/CREATE FUNCTION checkit/,
+        'Should have executed query';
+    is $warning, undef, 'Should have no warning';
+
+    $dbh->{err} = 'oops';
+    throws_ok { $mysql->_create_check_function } qr/oops/,
+        '_create_check_function() should rethrow unexpected DB error';
+    is $warning, undef, 'Should have no warning';
+
+    local *DBI::err;
+    $DBI::err = 1419;
+    lives_ok {$mysql->_create_check_function } 'Error 1419 should not be thrown';
+    like delete $dbh->{query}, qr/CREATE FUNCTION checkit/,
+        'Should have executed query';
+    is_deeply $warning, [__
+        'Insufficient permissions to create the checkit() function; skipping.',
+    ], 'Should have emitted a warning about checkit';
+    $warning = undef;
     $mock_sqitch->unmock_all;
 }
 


### PR DESCRIPTION
The permission check added in 93a0d1f (#824) does not work if the current user does not have permission to access the `mysql.user` table. So remove the permission check and move the creation of the `checkit` function to mysql.pm, where it ignores the failure to create the function due to a lack of sufficient permission or binary logging. Resolves #874.