### PR TITLE
Test that templates exist; add Cockroach templates

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ Revision history for Perl extension App::Sqitch
        user may not have such permission, and instead attempts to create the
        function and ignores a failure due to a lack of permission. Thanks to
        Alastair Douglas for the report and solution (#874)!
+     - Added missing CockroachDB templates. Thanks to @Peterbyte for the
+       report (#878)!
 
 1.5.1  2025-03-16T26:55:17Z
      - Fixed a bug introduced in v1.5.0 where the MySQL engine connected to

--- a/etc/templates/deploy/cockroach.tmpl
+++ b/etc/templates/deploy/cockroach.tmpl
@@ -1,0 +1,9 @@
+-- Deploy [% project %]:[% change %] to [% engine %]
+[% FOREACH item IN requires -%]
+-- requires: [% item %]
+[% END -%]
+[% FOREACH item IN conflicts -%]
+-- conflicts: [% item %]
+[% END -%]
+
+-- XXX Add DDLs here.

--- a/etc/templates/revert/cockroach.tmpl
+++ b/etc/templates/revert/cockroach.tmpl
@@ -1,0 +1,3 @@
+-- Revert [% project %]:[% change %] from [% engine %]
+
+-- XXX Add DDLs here.

--- a/etc/templates/verify/cockroach.tmpl
+++ b/etc/templates/verify/cockroach.tmpl
@@ -1,0 +1,3 @@
+-- Verify [% project %]:[% change %] on [% engine %]
+
+-- XXX Add verifications here.

--- a/t/cockroach.t
+++ b/t/cockroach.t
@@ -109,6 +109,9 @@ RUNREG: {
         'The registry should have been added to the search path';
 }
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($cockroach->key);
+
 ##############################################################################
 # Can we do live tests?
 $config->replace('core.engine' => 'cockroach');

--- a/t/exasol.t
+++ b/t/exasol.t
@@ -394,6 +394,9 @@ is_deeply [$exa->_regex_expr('corn', 'Obama')],
     ['corn REGEXP_LIKE ?', '.*Obama.*'],
     'Should append wildcards to both ends without anchors';
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($exa->key);
+
 ##############################################################################
 # Can we do live tests?
 my $dbh;

--- a/t/firebird.t
+++ b/t/firebird.t
@@ -391,6 +391,9 @@ FSPEC: {
     ), 'Client exception message should be correct';
 }
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($fb->key);
+
 ##############################################################################
 # Can we do live tests?
 my ($data_dir, $fb_version, @cleanup) = ($tmpdir);

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -6,6 +6,7 @@ use utf8;
 use Try::Tiny;
 use Test::More;
 use Test::Exception;
+use Test::File qw(file_exists_ok);
 use Time::HiRes qw(sleep tv_interval gettimeofday);
 use Path::Class 0.33 qw(file dir);
 use Digest::SHA qw(sha1_hex);
@@ -35,6 +36,7 @@ sub run {
         chomp  => 1,
         iomode => '<:raw'
     );
+
     # Each change should retain its own hash.
     my $orig_deploy_hash;
     $mock_change->mock(_deploy_hash => sub {
@@ -1911,6 +1913,17 @@ sub get_dependencies {
          WHERE change_id = ?
          ORDER BY dependency
     }, undef, shift);
+}
+
+sub test_templates_for {
+    my $key = $_[1];
+    # Make sure we have templates.
+    for my $action (qw(deploy revert verify)) {
+        my $fn = file(__FILE__)->dir->parent->parent->file(
+            qw(etc templates), $action, "$key.tmpl",
+        );
+        file_exists_ok($fn, "etc/templates/$action/$key.tml should exist");
+    }
 }
 
 1;

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -622,6 +622,9 @@ CHECKIT: {
     $mock_sqitch->unmock_all;
 }
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($mysql->key);
+
 ##############################################################################
 # Can we do live tests?
 my $dbh;

--- a/t/oracle.t
+++ b/t/oracle.t
@@ -623,6 +623,9 @@ is $change_id_in->(1042), join(
     'change_id IN (' . join(', ' => ('?') x 42) . ')'
 ), 'Should get 4 x 250 and 42 groups for 1042 IDs';
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($ora->key);
+
 ##############################################################################
 # Can we do live tests?
 if (App::Sqitch::ISWIN && eval { require Win32::API }) {

--- a/t/pg.t
+++ b/t/pg.t
@@ -471,6 +471,9 @@ RUNREG: {
         'Should have removed the :"registry" variable';
 }
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($pg->key);
+
 ##############################################################################
 # Can we do live tests?
 $config->replace('core.engine' => 'pg');

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -556,6 +556,9 @@ UPGRADE: {
     $mock_snow->unmock('dbh');
 }
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($snow->key);
+
 ##############################################################################
 # Can we do live tests?
 my $dbh;

--- a/t/sqlite.t
+++ b/t/sqlite.t
@@ -315,6 +315,9 @@ for my $v (qw(
 
 $mock_sqitch->unmock_all;
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($sqlite->key);
+
 ##############################################################################
 # Test against extra newline in capture.
 $sqlite_version = '3.7.12 2012-04-03 19:43:07 86b8481be7e76cccc92d14ce762d21bfb69504af';

--- a/t/vertica.t
+++ b/t/vertica.t
@@ -323,6 +323,9 @@ CID: {
         "_cid should propagate an error when it's not a table or column error";
 }
 
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($vta->key);
+
 ##############################################################################
 # Can we do live tests?
 my $dbh;


### PR DESCRIPTION
Add a method to DBIEngineTest that verifies that the templates exist for an engine key and put it to use in all of the engine tests. Add the missing CockroachDB templates. Resolves #878.