### PR TITLE
Use Snowflake key pair auth, quote identifiers

### DIFF
--- a/.github/ubuntu/snowflake.sh
+++ b/.github/ubuntu/snowflake.sh
@@ -9,27 +9,37 @@ if [ -z "$SKIP_DEPENDS" ]; then
     cat t/odbc/odbcinst.ini | sudo tee -a /etc/odbcinst.ini
 fi
 
+# Set the SnowSQL workspace.
+export WORKSPACE=/opt/snowflake
+
 # https://docs.snowflake.net/manuals/release-notes/client-change-log-snowsql.html
 # https://sfc-repo.snowflakecomputing.com/index.html
-curl -sSLo snowsql.bash https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.21-linux_x86_64.bash
+curl -sSLo snowsql.bash https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_x86_64/snowsql-1.3.2-linux_x86_64.bash
 curl -sSLo snowdbc.tgz https://sfc-repo.snowflakecomputing.com/odbc/linux/latest/snowflake_linux_x8664_odbc-3.5.0.tgz
 
 # Install and configure ODBC.
-mkdir -p /opt/snowflake
-sudo tar --strip-components 1 -C /opt/snowflake -xzf snowdbc.tgz
-sudo mv /opt/snowflake/ErrorMessages/en-US /opt/snowflake/lib/
+mkdir -p "$WORKSPACE/.snowsql"
+sudo tar --strip-components 1 -C "$WORKSPACE" -xzf snowdbc.tgz
+sudo mv "$WORKSPACE/ErrorMessages/en-US" "$WORKSPACE/lib/"
+
+# Set up the DSN for key pair auth.
+perl -npE 's/KEY_PASSWORD/$ENV{SNOWFLAKE_KEY_PASSWORD}/g' t/odbc/snowflake.ini | sudo tee -a /etc/odbc.ini
+printf "%s" "${SNOWFLAKE_KEY_FILE}" > "$WORKSPACE/rsa_key.p8"
 
 # Install, update, and configure SnowSQL.
-sed -e '1,/^exit$/d' snowsql.bash | sudo tar -C /opt/snowflake -zxf -
-/opt/snowflake/snowsql -Uv
-printf "[options]\nnoup = true\n" > /opt/snowflake/config
+sed -e '1,/^exit$/d' snowsql.bash | sudo tar -C "$WORKSPACE" -zxf -
+"$WORKSPACE/snowsql" -Uv
+(
+    printf "[connections]\nprivate_key_path=%s/rsa_key.p8\n\n" "$WORKSPACE"
+    printf "[options]\nnoup = true\n"
+) > "$WORKSPACE/.snowsql/config"
 
 # Add to the path.
 if [[ -n "$GITHUB_PATH" ]]; then
-    echo "/opt/snowflake" >> "$GITHUB_PATH"
+    echo "$WORKSPACE" >> "$GITHUB_PATH"
 fi
 
 # Tell SnowSQL where to find the config.
 if [[ -n "$GITHUB_ENV" ]]; then
-    echo "WORKSPACE=/opt/snowflake" >> "$GITHUB_ENV"
+    echo "WORKSPACE=$WORKSPACE" >> "$GITHUB_ENV"
 fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Setup Clients
         env:
           SKIP_DEPENDS: true
+          SNOWFLAKE_KEY_PASSWORD: ${{ secrets.SNOWFLAKE_KEY_PASSWORD }}
+          SNOWFLAKE_KEY_FILE: ${{ secrets.SNOWFLAKE_KEY_FILE }}
         run: |
           .github/ubuntu/all-apt-prereqs.sh
           .github/ubuntu/exasol.sh
@@ -92,7 +94,8 @@ jobs:
           LIVE_PG_REQUIRED: true
           SQITCH_TEST_PG_URI: db:pg://postgres@/postgres
           LIVE_SNOWFLAKE_REQUIRED: true
-          SQITCH_TEST_SNOWFLAKE_URI: db:snowflake://${{ secrets.SNOWFLAKE_USERNAME }}:${{ secrets.SNOWFLAKE_PASSWORD }}@sra81677.us-east-1/sqitchtest?Driver=Snowflake;warehouse=compute_wh
+          SNOWSQL_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_KEY_PASSWORD }}
+          SQITCH_TEST_SNOWFLAKE_URI: db:snowflake://${{ secrets.SNOWFLAKE_USERNAME }}@sra81677.us-east-1/sqitchtest?DSN=sqitch;warehouse=compute_wh
           LIVE_SQLITE_REQUIRED: true
           LIVE_VERTICA_REQUIRED: true
           SQITCH_TEST_VSQL_URI: db:vertica://dbadmin@localhost:${{ job.services.vertica.ports[5433] }}/VMart?Driver=Vertica

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Clients
+        env:
+          SNOWFLAKE_KEY_PASSWORD: ${{ secrets.SNOWFLAKE_KEY_PASSWORD }}
+          SNOWFLAKE_KEY_FILE: ${{ secrets.SNOWFLAKE_KEY_FILE }}
         run: .github/ubuntu/snowflake.sh
       - name: Setup Perl
         id: perl
@@ -29,5 +32,6 @@ jobs:
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"
           LIVE_SNOWFLAKE_REQUIRED: true
-          SQITCH_TEST_SNOWFLAKE_URI: db:snowflake://${{ secrets.SNOWFLAKE_USERNAME }}:${{ secrets.SNOWFLAKE_PASSWORD }}@sra81677.us-east-1/sqitchtest?Driver=Snowflake;warehouse=compute_wh
+          SNOWSQL_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_KEY_PASSWORD }}
+          SQITCH_TEST_SNOWFLAKE_URI: db:snowflake://${{ secrets.SNOWFLAKE_USERNAME }}@sra81677.us-east-1/sqitchtest?DSN=sqitch;warehouse=compute_wh
         run: prove -lvr t/snowflake.t

--- a/Changes
+++ b/Changes
@@ -11,6 +11,20 @@ Revision history for Perl extension App::Sqitch
        Alastair Douglas for the report and solution (#874)!
      - Added missing CockroachDB templates. Thanks to @Peterbyte for the
        report (#878)!
+     - Removed support for the `SNOWSQL_PORT` environment variable, which has
+       long been deprecated by Snowflake and likely never did anything.
+     - Fixed the quoting of the role and schema names on connecting to
+       Snowflake, which was silently failing and thus failing to properly use
+       the registry schema, which lead to a failure to find the registry.
+       Broken in v1.5.1.
+     - Added redaction of passwords from Snowflake URL query parameters in the
+       display URL. Any query parameter matching `pwd` will now be shown as
+       "REDACTED".
+     - Expanded the documentation of Snowflake key pair authentication in
+      `sqitch-authentication.pod` to recommend setting sensitive ODBC
+       parameters in an `odbc.ini` file rather than connection URL query
+       parameters.
+     - Switched to key pair authentication in the Snowflake CI workflows.
 
 1.5.1  2025-03-16T26:55:17Z
      - Fixed a bug introduced in v1.5.0 where the MySQL engine connected to

--- a/lib/sqitch-authentication.pod
+++ b/lib/sqitch-authentication.pod
@@ -159,16 +159,28 @@ query string, e.g.,
 
 Snowflake does not support password-less authentication, but does support
 key-pair authentication. Follow
-L<the instructions|https://docs.snowflake.com/en/user-guide/snowsql-start.html#using-key-pair-authentication>
-to create a key pair, then set the following variables in the F<~/.snowsql/config>
-file:
+L<the instructions|https://docs.snowflake.com/en/user-guide/key-pair-auth>
+to create a key pair, then set the C<private_key_path> in the F<~/.snowsql/config>
+to point to the private key file:
 
-  authenticator = SNOWFLAKE_JWT
-  private_key_path = "path/to/privatekey.p8"
+  private_key_path = "<path>/rsa_key.p8"
 
 To connect, set the C<$SNOWSQL_PRIVATE_KEY_PASSPHRASE> environment variable to
-the passphrase for the private key, and add these parameters to the query part
-of your connection URI:
+the passphrase for the private key, and add these parameters under the
+configuration for your DSN in F</etc/odbc.ini> or F<~/.odbc.ini>:
+
+  [sqitch]
+  AUTHENTICATOR     = SNOWFLAKE_JWT
+  UID               = <username>
+  PRIV_KEY_FILE     = <path>/rsa_key.p8
+  PRIV_KEY_FILE_PWD = <password>
+
+Then connect using the named DSN via the C<DSN> query parameter:
+
+  db:snowflake://movera@example.snowflakecomputing.com/flipr?warehouse=compute_wh;DSN=sqitch
+
+Or add the ODBC parameters directly to the query part of your connection URI
+(although it's safer to put C<priv_key_file_pwd> in F<odbc.ini>):
 
 =over
 
@@ -185,6 +197,10 @@ of your connection URI:
 For example:
 
   db:snowflake://movera@example.snowflakecomputing.com/flipr?Driver=Snowflake;warehouse=sqitch;authenticator=SNOWFLAKE_JWT;uid=movera;priv_key_file=path/to/privatekey.p8;priv_key_file_pwd=s0up3rs3cre7
+
+Sadly, both the C<SNOWSQL_PRIVATE_KEY_PASSPHRASE> environment variable and
+the C<priv_key_file_pwd> ODBC parameter must be set, as Sqitch uses ODBC to
+maintain its registry and SnowSQL to execute change scripts.
 
 =back
 

--- a/lib/sqitch-environment.pod
+++ b/lib/sqitch-environment.pod
@@ -316,11 +316,6 @@ parameter.
 The Snowflake server host to connect to. Superseded by the target URI host
 name. Deprecated by Snowflake.
 
-=item C<SNOWSQL_PORT>
-
-The Snowflake server port to connect to. Superseded by the target URI port.
-Deprecated by Snowflake.
-
 =item C<SNOWSQL_REGION>
 
 The Snowflake region. Superseded by the target URI host name. Deprecated by

--- a/t/odbc/snowflake.ini
+++ b/t/odbc/snowflake.ini
@@ -1,0 +1,9 @@
+[ODBC Data Sources]
+sqitch = Snowflake
+
+[sqitch]
+Driver            = /opt/snowflake/lib/libSnowflake.so
+ACCOUNT           = YOHTWZV-ZSA24461
+AUTHENTICATOR     = SNOWFLAKE_JWT
+PRIV_KEY_FILE     = /opt/snowflake/rsa_key.p8
+PRIV_KEY_FILE_PWD = KEY_PASSWORD

--- a/t/snowflake.t
+++ b/t/snowflake.t
@@ -32,7 +32,7 @@ use TestConfig;
 
 my $CLASS;
 
-delete $ENV{"SNOWSQL_$_"} for qw(USER PASSWORD DATABASE HOST PORT);
+delete $ENV{"SNOWSQL_$_"} for qw(USER PASSWORD DATABASE HOST);
 
 BEGIN {
     $CLASS = 'App::Sqitch::Engine::snowflake';
@@ -87,6 +87,30 @@ is $snow->destination, $exp_uri, 'Destination should be URI string';
 is $snow->registry_destination, $snow->destination,
     'Registry destination should be the same as destination';
 
+# Test destination URI redaction.
+PASSWORDS: {
+    my $sensitive_uri = "db:snowflake://julie:s3cr3t@/?pwd=xyz;key_pwd=abc;pod=x";
+    my $target = App::Sqitch::Target->new(
+        sqitch => $sqitch,
+        uri    => URI::db->new($sensitive_uri),
+    );
+    isa_ok my $sensitive_snow = $CLASS->new(
+        sqitch => $sqitch,
+        target => $target,
+    ), $CLASS;
+
+    # Test URI.
+    my $exp = URI::db->new($sensitive_uri);
+    $exp->host("$ENV{SNOWSQL_ACCOUNT}.snowflakecomputing.com");
+    $exp->dbname('julie');
+    is $sensitive_snow->uri, $exp, 'Should have sensitive info in URI';
+
+    # Test redacted destination URI.
+    $exp->query('pwd=REDACTED;key_pwd=REDACTED;pod=x');
+    $exp->password(undef);
+    is $sensitive_snow->destination, $exp, 'Should have sensitive info in URI';
+}
+
 # Test environment variables.
 SNOWENV: {
     local $ENV{SNOWSQL_USER} = 'kamala';
@@ -95,12 +119,11 @@ SNOWENV: {
     local $ENV{SNOWSQL_WAREHOUSE} = 'madrigal';
     local $ENV{SNOWSQL_ACCOUNT} = 'egregious';
     local $ENV{SNOWSQL_HOST} = 'test.us-east-2.aws.snowflakecomputing.com';
-    local $ENV{SNOWSQL_PORT} = 4242;
     local $ENV{SNOWSQL_DATABASE} = 'tryme';
 
     my $target = App::Sqitch::Target->new(sqitch => $sqitch, uri => URI->new($uri));
     my $snow = $CLASS->new( sqitch => $sqitch, target => $target );
-    is $snow->uri, 'db:snowflake://test.us-east-2.aws.snowflakecomputing.com:4242/tryme',
+    is $snow->uri, 'db:snowflake://test.us-east-2.aws.snowflakecomputing.com/tryme',
         'Should build URI from environment';
     is $snow->username, 'kamala', 'Should read username from environment';
     is $snow->password, 'gimme', 'Should read password from environment';
@@ -112,7 +135,7 @@ SNOWENV: {
     delete $ENV{SNOWSQL_HOST};
     $snow = $CLASS->new( sqitch => $sqitch, target => $target );
     is $snow->uri,
-        'db:snowflake://egregious.Australia.snowflakecomputing.com:4242/tryme',
+        'db:snowflake://egregious.Australia.snowflakecomputing.com/tryme',
         'Should build URI host from account and region environment vars';
     is $snow->account, 'egregious.Australia',
         'Should read account and region from environment';


### PR DESCRIPTION
Switch to key pair authentication in the Snowflake workflows, as password-only authentication will be discontinued later this year. In the process, work out and document how to set the appropriate ODBC parameters in an `odbc.ini` file in preference to the connection URL.

Refactor `snowflake.sh` to∑ set `WORKSPACE` when installing SnowSQL, which is required to upgrade to v1.3. Use the variable instead of heard-coded paths throughout, and fix the location of the configuration file (it has to go into the `.snowsql` subdirectory of the workspace). Copy and update an `odbc.ini` and `.snowsql/config` as needed for key pair auth.

Fix the quoting of the role and schema names on connecting to Snowflake, which were silently failing and therefore failing to properly use the registry schema, which lead to a failure to find the registry. Broken in 33291bd (#853).

While at it, remove support for the `SNOWSQL_PORT` environment variable, which has long been deprecated by Snowflake and likely never did anything. Also add redaction of passwords from Snowflake URL query parameters in the display URL. Any query parameter matching `pwd` will now be shown as "REDACTED".