### PR TITLE
Add ClickHouse Engine

### DIFF
--- a/.github/ubuntu/clickhouse.sh
+++ b/.github/ubuntu/clickhouse.sh
@@ -4,9 +4,17 @@ set -e
 
 if [ -z "$SKIP_DEPENDS" ]; then
     sudo apt-get update -qq
-    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq unixodbc-dev odbcinst unixodbc clickhouse-client
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq unixodbc-dev odbcinst unixodbc
     cat t/odbc/odbcinst.ini | sudo tee -a /etc/odbcinst.ini
 fi
+
+# https://clickhouse.com/docs/install
+sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq apt-transport-https ca-certificates curl gnupg
+curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | sudo gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg
+ARCH=$(dpkg --print-architecture)
+echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=${ARCH}] https://packages.clickhouse.com/deb stable main" | sudo tee /etc/apt/sources.list.d/clickhouse.list
+sudo apt-get update -qq
+sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq clickhouse-client
 
 cat t/odbc/clickhouse.ini | sudo tee -a /etc/clickhouse.ini
 

--- a/.github/ubuntu/clickhouse.sh
+++ b/.github/ubuntu/clickhouse.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$SKIP_DEPENDS" ]; then
+    sudo apt-get update -qq
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq unixodbc-dev odbcinst unixodbc clickhouse-client
+    cat t/odbc/odbcinst.ini | sudo tee -a /etc/odbcinst.ini
+fi
+
+cat t/odbc/clickhouse.ini | sudo tee -a /etc/clickhouse.ini
+
+# Prepare the configuration.
+mkdir -p /opt/clickhouse
+
+# https://github.com/ClickHouse/clickhouse-odbc/releases
+curl -sSLO https://github.com/ClickHouse/clickhouse-odbc/releases/download/1.4.3.20250807/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip
+unzip -p clickhouse-odbc-linux-Clang-UnixODBC-Release.zip 'clickhouse-odbc-1.4.3-Linux.tar.gz' | tar -xzf - -C /opt/clickhouse --strip-components 1

--- a/.github/ubuntu/clickhouse.sh
+++ b/.github/ubuntu/clickhouse.sh
@@ -16,8 +16,6 @@ echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=${ARCH}] ht
 sudo apt-get update -qq
 sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq clickhouse-client
 
-cat t/odbc/clickhouse.ini | sudo tee -a /etc/clickhouse.ini
-
 # Prepare the configuration.
 mkdir -p /opt/clickhouse
 

--- a/.github/ubuntu/pg.sh
+++ b/.github/ubuntu/pg.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-PGVERSION=${PGVERSION:=${1:-18}}
+PGVERSION=${PGVERSION:=${1:-"$(curl -s https://ftp.postgresql.org/pub/latest/ | perl -ne '/postgresql-(\d+)/ && print($1) && exit')"}}
 [[ $PGVERSION =~ ^[0-9]$ ]] && PGVERSION+=.0
+echo "Installing PostgreSQL $PGVERSION"
 
 curl -O https://salsa.debian.org/postgresql/postgresql-common/-/raw/master/pgdg/apt.postgresql.org.sh
 sudo sh apt.postgresql.org.sh -i -t -v $PGVERSION

--- a/.github/ubuntu/sqlite.sh
+++ b/.github/ubuntu/sqlite.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-SQLITE=${SQLITE:=${1:-3.40.1}}
-echo "Instaling SQLite $SQLITE"
+SQLITE=${SQLITE:=${1:-"$(curl -s https://www.sqlite.org/download.html | perl -nE '/^PRODUCT,(\d[^,]+)/ && print($1) && exit')"}}
+echo "Installing SQLite $SQLITE"
 
 # Convert to the SQLITE_VERSION_NUMBER format https://sqlite.org/c3ref/c_source_id.html
 SQLITE=$(perl -e 'my @v = split /[.]/, shift; printf "%d%02d%02d%02d\n", @v[0..3]' "$SQLITE")

--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -1,0 +1,47 @@
+# This workflow tests Sqitch's ClickHouse engine on recent supported versions
+# of Oracle. It runs for pushes to branches matching `main`, `develop`,
+# `**clickhouse**`, and `**engine**`.
+name: 🏠 ClickHouse
+on:
+  push:
+    branches: [main, develop, "**engine**", "**clickhouse**" ]
+jobs:
+  ClickHouse:
+    strategy:
+      matrix:
+        clickhouse: ['25.8']
+    name: 🏠 ClickHouse ${{ matrix.clickhouse }}
+    runs-on: ubuntu-latest
+    services:
+      clickhouse:
+        image: clickhouse:${{ matrix.clickhouse }}
+        ports: [ 8123, 9000 ]
+        env:
+          CLICKHOUSE_SKIP_USER_SETUP: 1
+        options: >-
+          --ulimit nofile=262144:262144
+          --health-cmd "clickhouse-client --query 'SELECT 1'"
+          --health-interval 20s
+          --health-timeout 10s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Clients
+        run: .github/ubuntu/clickhouse.sh
+      - name: Setup Perl
+        id: perl
+        uses: shogo82148/actions-setup-perl@v1
+        with: { perl-version: latest }
+      - name: Cache CPAN Modules
+        uses: actions/cache@v4
+        with:
+          path: local
+          key: perl-${{ steps.perl.outputs.perl-hash }}
+      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
+      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::ODBC
+      - name: prove
+        env:
+          PERL5LIB: "${{ github.workspace }}/local/lib/perl5"
+          LIVE_CLICKHOUSE_REQUIRED: true
+          SQITCH_TEST_CLICKHOUSE_URI: db:clickhouse://default@localhost:${{ job.services.clickhouse.ports[8123] }}/default?Driver=ClickHouse&NativePort=${{ job.services.clickhouse.ports[9000] }}
+        run: prove -lvr t/clickhouse.t

--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -1,10 +1,10 @@
 # This workflow tests Sqitch's ClickHouse engine on recent supported versions
-# of Oracle. It runs for pushes to branches matching `main`, `develop`,
-# `**clickhouse**`, and `**engine**`.
+# of ClickHouse. It runs on pushes to branches matching `develop`,
+# `**clickhouse**`, and `**engine**` as well as pull requests.
 name: 🏠 ClickHouse
 on:
   push:
-    branches: [main, develop, "**engine**", "**clickhouse**" ]
+    branches: [develop, "**engine**", "**clickhouse**" ]
 jobs:
   ClickHouse:
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,6 +43,17 @@ jobs:
       vertica:
         image: cjonesy/docker-vertica:9.2.1-0
         ports: [ 5433 ]
+      clickhouse:
+        image: clickhouse:latest
+        ports: [ 8123, 9000 ]
+        env:
+          CLICKHOUSE_SKIP_USER_SETUP: 1
+        options: >-
+          --ulimit nofile=262144:262144
+          --health-cmd "clickhouse-client --query 'SELECT 1'"
+          --health-interval 20s
+          --health-timeout 10s
+          --health-retries 10
     steps:
       # https://github.com/orgs/community/discussions/25678#discussioncomment-9017167
       - name: Free Disk Space
@@ -69,6 +80,7 @@ jobs:
           SNOWFLAKE_KEY_FILE: ${{ secrets.SNOWFLAKE_KEY_FILE }}
         run: |
           .github/ubuntu/all-apt-prereqs.sh
+          .github/ubuntu/clickhouse.sh
           .github/ubuntu/exasol.sh
           .github/ubuntu/firebird.sh
           .github/ubuntu/mysql.sh
@@ -101,6 +113,8 @@ jobs:
           SQITCH_TEST_VSQL_URI: db:vertica://dbadmin@localhost:${{ job.services.vertica.ports[5433] }}/docker?Driver=Vertica
           LIVE_COCKROACH_REQUIRED: true
           SQITCH_TEST_COCKROACH_URI: db:cockroach://root@localhost:26257/
+          LIVE_CLICKHOUSE_REQUIRED: true
+          SQITCH_TEST_CLICKHOUSE_URI: db:clickhouse://default@localhost:${{ job.services.clickhouse.ports[8123] }}/default?Driver=ClickHouse&NativePort=${{ job.services.clickhouse.ports[9000] }}
         run: prove -lrj4 t
       - name: Report Coverage
         env:

--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ Revision history for Perl extension App::Sqitch
        replaces inline uses of `split`. This allows the tests to more
        consistently compare arrays as arrays, though `search_events` must now
        always parse `tags`, `requires`, and `conflicts`.
+     - Added support for ClickHouse. It relies on the C<clickhouse> CLI and
+       ODBC driver. Like MySQL, it uses a database for the registry schema,
+       where the tables use the C<MergeTree> engine.
 
 1.5.2  2025-04-29T15:13:35Z
      - Added missing German translations, thanks to @0xflotus for the PR

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 App/Sqitch version v1.5.3-dev
 =========================
 
-| Release           | Coverage          | Database                              ||
-|-------------------|-------------------|-------------------|--------------------|
-| [![CPAN]][📚]     | [![OSes]][💿]     | [![Exasol]][☀️]    | [![Oracle]][🔮]    |
-| [![Docker]][🐳]   | [![Perl]][🧅]     | [![Firebird]][🔥] | [![Snowflake]][❄️]  |
-| [![Homebrew]][🍺] | [![Coverage]][📈] | [![MySQL]][🐬]    | [![SQLite]][💡]    |
-| [![Debian]][🍥]   |                   | [![Postgres]][🐘] | [![Vertica]][🔺]   |
-|                   |                   | [![Yugabyte]][💫] | [![Cockroach]][🪳] |
+| Release           | Coverage          | Database                                                |||
+|-------------------|-------------------|-------------------|------------------|--------------------|
+| [![CPAN]][📚]      | [![OSes]][💿]      | [![Postgres]][🐘]  | [![SQLite]][💡]   | [![MySQL]][🐬]      |
+| [![Docker]][🐳]    | [![Perl]][🧅]      | [![Yugabyte]][💫]  | [![Firebird]][🔥] | [![MariaDB]][🦭]    |
+| [![Homebrew]][🍺]  | [![Coverage]][📈]  | [![Cockroach]][🪳] | [![Exasol]][☀️]   | [![ClickHouse]][🏠] |
+| [![Debian]][🍥]    |                   | [![Snowflake]][❄️] | [![Oracle]][🔮]   | [![Vertica]][🔺]    |
+
 
 [Sqitch] is a database change management application. It currently supports:
 
@@ -22,6 +22,7 @@ App/Sqitch version v1.5.3-dev
 *   [Vertica][vert] 7.2+
 *   [Exasol][exa] 6.0+
 *   [Snowflake][flake]
+*   [ClickHouse][click] 25.8+
 
 What makes it different from your typical migration approaches? A few things:
 
@@ -179,7 +180,9 @@ SOFTWARE.
   [Coverage]:  https://img.shields.io/coveralls/github/sqitchers/sqitch?label=%F0%9F%93%88%20Coverage
   [📈]:        https://coveralls.io/r/sqitchers/sqitch "Test Coverage"
   [MySQL]:     https://github.com/sqitchers/sqitch/actions/workflows/mysql.yml/badge.svg
-  [🐬]:        https://github.com/sqitchers/sqitch/actions/workflows/mysql.yml "Tested with MySQL 5.5–9.1 and MariaDB 10.0–12.0"
+  [🐬]:        https://github.com/sqitchers/sqitch/actions/workflows/mysql.yml "Tested with MySQL 5.5–9.1"
+  [MariaDB]:   https://github.com/sqitchers/sqitch/actions/workflows/maria.yml/badge.svg
+  [🦭]:        https://github.com/sqitchers/sqitch/actions/workflows/maria.yml "Tested with MariaDB 10.0–12.0"
   [SQLite]:    https://github.com/sqitchers/sqitch/actions/workflows/sqlite.yml/badge.svg
   [💡]:        https://github.com/sqitchers/sqitch/actions/workflows/sqlite.yml "Tested with SQLite 3.8–3.50"
   [Debian]:    https://img.shields.io/debian/v/sqitch?label=%F0%9F%8D%A5%20Debian
@@ -190,8 +193,10 @@ SOFTWARE.
   [💫]:        https://github.com/sqitchers/sqitch/actions/workflows/yugabyte.yml "Tested with YugabyteDB 2.6–2025.1"
   [Vertica]:   https://github.com/sqitchers/sqitch/actions/workflows/vertica.yml/badge.svg
   [🔺]:        https://github.com/sqitchers/sqitch/actions/workflows/vertica.yml "Tested with Vertica 7.2–12.0"
-[Cockroach]: https://github.com/sqitchers/sqitch/actions/workflows/cockroach.yml/badge.svg
+  [Cockroach]: https://github.com/sqitchers/sqitch/actions/workflows/cockroach.yml/badge.svg
   [🪳]:        https://github.com/sqitchers/sqitch/actions/workflows/cockroach.yml "Tested with CockroachDB v21-24"
+  [ClickHouse]: https://github.com/sqitchers/sqitch/actions/workflows/clickhouse.yml/badge.svg
+  [🏠]:          https://github.com/sqitchers/sqitch/actions/workflows/clickhouse.yml "Tested with ClickHouse v25.8"
 
   [Sqitch]: https://sqitch.org/
   [PostgreSQL]: https://postgresql.org/
@@ -206,6 +211,7 @@ SOFTWARE.
   [vert]: https://www.vertica.com/
   [exa]: https://www.exasol.com/
   [flake]: https://www.snowflake.net/
+  [click]: https://clickhouse.com/clickhouse
   [SQL\*Plus]: https://www.orafaq.com/wiki/SQL*Plus
   [Merkle tree]: https://en.wikipedia.org/wiki/Merkle_tree "Wikipedia: “Merkle tree”"
   [gitmerkle]: https://stackoverflow.com/a/18589734/

--- a/dist.ini
+++ b/dist.ini
@@ -141,3 +141,8 @@ DBD::ODBC = 1.59
 -description = Include the ODBC driver.
 -prompt = 0
 DBD::ODBC = 1.59
+
+[OptionalFeature / clickhouse]
+-description = Support for managing ClickHouse databases
+-prompt = 0
+DBD::ODBC = 1.59

--- a/dist/sqitch.spec
+++ b/dist/sqitch.spec
@@ -308,6 +308,25 @@ also be installed.
 %files snowflake
 # No additional files required.
 
+%package snowflake
+Summary:        Sensible database change management for ClickHouse
+Group:          Development/Libraries
+Requires:       sqitch >= %{version}
+Requires:       perl(DBI) => 1.631
+Requires:       perl(DBD::ODBC) >= 1.59
+Requires:       libclickhouseodbcw.so
+Requires:       /usr/bin/clickhouse
+Provides:       sqitch-clickhouse
+
+%description clickhouse
+Sqitch provides a simple yet robust interface for database change management.
+The philosophy and functionality is inspired by Git. This package bundles the
+Sqitch ClickHouse support. It requires that the CLickHouse client and ODBC
+driver also be installed.
+
+%files clickhouse
+# No additional files required.
+
 %changelog
 * Mon Apr 29 2025 David E. Wheeler <david@justatheory.com> 1.5.2-1
 - Upgrade to v1.5.2.

--- a/etc/templates/deploy/clickhouse.tmpl
+++ b/etc/templates/deploy/clickhouse.tmpl
@@ -1,0 +1,9 @@
+-- Deploy [% project %]:[% change %] to [% engine %]
+[% FOREACH item IN requires -%]
+-- requires: [% item %]
+[% END -%]
+[% FOREACH item IN conflicts -%]
+-- conflicts: [% item %]
+[% END -%]
+
+-- XXX Add DDLs here.

--- a/etc/templates/revert/clickhouse.tmpl
+++ b/etc/templates/revert/clickhouse.tmpl
@@ -1,0 +1,3 @@
+-- Revert [% project %]:[% change %] from [% engine %]
+
+-- XXX Add DDLs here.

--- a/etc/templates/verify/clickhouse.tmpl
+++ b/etc/templates/verify/clickhouse.tmpl
@@ -1,0 +1,3 @@
+-- Verify [% project %]:[% change %] on [% engine %]
+
+-- XXX Add verifications here.

--- a/lib/App/Sqitch/Command.pm
+++ b/lib/App/Sqitch/Command.pm
@@ -24,6 +24,7 @@ use constant ENGINES => qw(
     exasol
     snowflake
     cockroach
+    clickhouse
 );
 
 has sqitch => (
@@ -371,6 +372,8 @@ Returns the list of supported engines, currently:
 =item * C<snowflake>
 
 =item * C<cockroach>
+
+=item * C<clickhouse>
 
 =back
 

--- a/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.0.sql
+++ b/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.0.sql
@@ -7,6 +7,7 @@ CREATE TABLE releases (
     installer_email TEXT                 NOT NULL
                     COMMENT 'Email address of the user who installed the registry release.'
 ) ENGINE = MergeTree
+  ORDER BY version
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch registry releases.';
 

--- a/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.0.sql
+++ b/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.0.sql
@@ -7,13 +7,11 @@ CREATE TABLE releases (
     installer_email TEXT                 NOT NULL
                     COMMENT 'Email address of the user who installed the registry release.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch registry releases.';
 
 -- Add the script_hash column to the changes table. Copy change_id for now.
 ALTER TABLE changes ADD COLUMN script_hash TEXT COMMENT 'Deploy script SHA-1 hash.';
-ALTER TABLE changes MODIFY SETTING
-    enable_block_number_column = 1,
-    enable_block_offset_column = 1;
 UPDATE changes SET script_hash = change_id WHERE TRUE;
 
 -- Allow "merge" events.

--- a/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.0.sql
+++ b/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.0.sql
@@ -1,0 +1,22 @@
+CREATE TABLE releases (
+    version         REAL COMMENT 'Version of the Sqitch registry.' PRIMARY KEY,
+    installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
+                    COMMENT 'Date the registry release was installed.',
+    installer_name  TEXT                 NOT NULL
+                    COMMENT 'Name of the user who installed the registry release.',
+    installer_email TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who installed the registry release.'
+) ENGINE = MergeTree
+  COMMENT 'Sqitch registry releases.';
+
+-- Add the script_hash column to the changes table. Copy change_id for now.
+ALTER TABLE changes ADD COLUMN script_hash TEXT COMMENT 'Deploy script SHA-1 hash.';
+ALTER TABLE changes MODIFY SETTING
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1;
+UPDATE changes SET script_hash = change_id WHERE TRUE;
+
+-- Allow "merge" events.
+ALTER TABLE events DROP CONSTRAINT IF EXISTS events_event_check;
+ALTER TABLE events ADD  CONSTRAINT events_event_check
+      CHECK (event IN ('deploy', 'revert', 'fail', 'merge'));

--- a/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.1.sql
+++ b/lib/App/Sqitch/Engine/Upgrade/clickhouse-1.1.sql
@@ -1,0 +1,1 @@
+--No unique key in ClickHouse, so no changes.

--- a/lib/App/Sqitch/Engine/clickhouse.pm
+++ b/lib/App/Sqitch/Engine/clickhouse.pm
@@ -586,40 +586,34 @@ App::Sqitch::Engine::clickhouse - Sqitch ClickHouse Engine
 =head1 Description
 
 App::Sqitch::Engine::clickhouse provides the ClickHouse storage engine for Sqitch. It
-supports ClickHouse 5.1.0 and higher (best on 5.6.4 and higher), as well as MariaDB
-5.3.0 and higher.
+supports ClickHouse v25.8 and higher.
 
 =head1 Interface
 
 =head2 Instance Methods
 
-=head3 C<clickhouse>
+=head3 C<cli>
 
 Returns a list containing the C<clickhouse> client and options to be passed to it.
-Used internally when executing scripts. Query parameters in the URI that map
-to C<clickhouse> client options will be passed to the client, as follows:
+Used internally when executing scripts.
+L<Query parameters|https://github.com/clickHouse/clickhouse-odbc> in the URI
+that map to C<clickhouse> client options will be passed to the client, as
+follows:
 
 =over
 
-=item * C<clickhouse_compression=1>: C<--compress>
+=item * C<SSLMode>: C<--secure>
 
-=item * C<clickhouse_ssl=1>: C<--ssl>
+Assume that TLS is required in the client if SSLMode is set.
 
-=item * C<clickhouse_connect_timeout>: C<--connect_timeout>
+=item * C<NativePort>: C<--port>
 
-=item * C<clickhouse_init_command>: C<--init-command>
-
-=item * C<clickhouse_socket>: C<--socket>
-
-=item * C<clickhouse_ssl_client_key>: C<--ssl-key>
-
-=item * C<clickhouse_ssl_client_cert>: C<--ssl-cert>
-
-=item * C<clickhouse_ssl_ca_file>: C<--ssl-ca>
-
-=item * C<clickhouse_ssl_ca_path>: C<--ssl-capath>
-
-=item * C<clickhouse_ssl_cipher>: C<--ssl-cipher>
+Sqitch-specific parameter for the client port. Required because the
+ODBC driver uses the HTTP ports (8123 or 8443 with C<SSLMode>) while the
+ClickHouse CLI uses the Native Protocol port (9000 or 9440 with C<SSLMode>).
+Use this option to specify an alternative port for the CLI. See
+L<Network Ports|https://clickhouse.com/docs/guides/sre/network-ports> for
+additional information.
 
 =back
 
@@ -628,11 +622,8 @@ to C<clickhouse> client options will be passed to the client, as follows:
 =head3 C<password>
 
 Overrides the methods provided by the target so that, if the target has
-no username or password, Sqitch looks them up in the
-L<F</etc/my.cnf> and F<~/.my.cnf> files|https://dev.clickhouse.com/doc/refman/5.7/en/password-security-user.html>.
-These files must limit access only to the current user (C<0600>). Sqitch will
-look for a username and password under the C<[client]> and C<[clickhouse]>
-sections, in that order.
+no username or password, Sqitch can look them up in a configuration file
+(although it does not yet do so).
 
 =head1 Author
 

--- a/lib/App/Sqitch/Engine/clickhouse.sql
+++ b/lib/App/Sqitch/Engine/clickhouse.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE releases (
-    version         REAL COMMENT 'Version of the Sqitch registry.' PRIMARY KEY,
+    version         REAL                 NOT NULL
+                    COMMENT 'Version of the Sqitch registry.',
     installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the registry release was installed.',
     installer_name  TEXT                 NOT NULL
@@ -8,12 +9,15 @@ CREATE TABLE releases (
     installer_email TEXT                 NOT NULL
                     COMMENT 'Email address of the user who installed the registry release.'
 ) ENGINE = MergeTree
+  PRIMARY KEY version
+  ORDER BY version
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch registry releases.';
 
 CREATE TABLE projects (
-    project         TEXT        COMMENT 'Unique Name of a project.' PRIMARY KEY,
-    uri             TEXT                 NULL
+    project         TEXT                 NOT NULL
+                    COMMENT 'Unique Name of a project.',
+    uri             TEXT                     NULL
                     COMMENT 'Optional project URI',
     created_at      DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the project was added to the database.',
@@ -22,11 +26,14 @@ CREATE TABLE projects (
     creator_email   TEXT                 NOT NULL
                     COMMENT 'Email address of the user who added the project.'
 ) ENGINE = MergeTree
+  PRIMARY KEY project
+  ORDER BY project
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch projects deployed to this database.';
 
 CREATE TABLE changes (
-    change_id       TEXT        COMMENT 'Change primary key.' PRIMARY KEY,
+    change_id       TEXT        NOT NULL
+                    COMMENT 'Change primary key.',
     script_hash     TEXT            NULL
                     COMMENT 'Deploy script SHA-1 hash.',
     change          TEXT        NOT NULL
@@ -48,11 +55,14 @@ CREATE TABLE changes (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the change.'
 ) ENGINE = MergeTree
+  PRIMARY KEY (project, change_id)
+  ORDER BY (project, change_id)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the changes currently deployed to the database.';
 
 CREATE TABLE tags (
-    tag_id          TEXT        COMMENT 'Tag primary key.' PRIMARY KEY,
+    tag_id          TEXT        NOT NULL
+                    COMMENT 'Tag primary key.',
     tag             TEXT        NOT NULL
                     COMMENT 'Project-unique tag name.',
     project         TEXT        NOT NULL
@@ -74,6 +84,8 @@ CREATE TABLE tags (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the tag.'
 ) ENGINE = MergeTree
+  PRIMARY KEY (project, change_id, tag_id)
+  ORDER BY (project, change_id, tag_id)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
@@ -92,11 +104,12 @@ CREATE TABLE dependencies (
     )    
 ) ENGINE = MergeTree
   PRIMARY KEY (change_id, dependency)
+  ORDER BY (change_id, dependency)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
 CREATE TABLE events (
-    event           TEXT        NOT NULL
+    event           TEXT                 NOT NULL
                     COMMENT 'Type of event.',
     CONSTRAINT events_event_check CHECK (
         event IN ('deploy', 'revert', 'fail', 'merge')
@@ -128,6 +141,7 @@ CREATE TABLE events (
     planner_email   TEXT                 NOT NULL
                     COMMENT 'Email address of the user who plan planned the change.',
 ) ENGINE = MergeTree
-  PRIMARY KEY (committed_at, change_id)
+  PRIMARY KEY (project, committed_at)
+  ORDER BY (project, committed_at)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Contains full history of all deployment events.';

--- a/lib/App/Sqitch/Engine/clickhouse.sql
+++ b/lib/App/Sqitch/Engine/clickhouse.sql
@@ -1,0 +1,127 @@
+
+CREATE TABLE releases (
+    version         REAL COMMENT 'Version of the Sqitch registry.' PRIMARY KEY,
+    installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+                    COMMENT 'Date the registry release was installed.',
+    installer_name  TEXT                 NOT NULL
+                    COMMENT 'Name of the user who installed the registry release.',
+    installer_email TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who installed the registry release.'
+) ENGINE = MergeTree
+  COMMENT 'Sqitch registry releases.';
+
+CREATE TABLE projects (
+    project         TEXT        COMMENT 'Unique Name of a project.' PRIMARY KEY,
+    uri             TEXT                 NULL
+                    COMMENT 'Optional project URI',
+    created_at      DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+                    COMMENT 'Date the project was added to the database.',
+    creator_name    TEXT                 NOT NULL
+                    COMMENT 'Name of the user who added the project.',
+    creator_email   TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who added the project.'
+) ENGINE = MergeTree
+  COMMENT 'Sqitch projects deployed to this database.';
+
+CREATE TABLE changes (
+    change_id       TEXT        COMMENT 'Change primary key.' PRIMARY KEY,
+    script_hash     TEXT            NULL
+                    COMMENT 'Deploy script SHA-1 hash.',
+    change          TEXT        NOT NULL
+                    COMMENT 'Name of a deployed change.',
+    project         TEXT        NOT NULL
+                    COMMENT 'Name of the Sqitch project to which the change belongs.',
+    note            TEXT        NOT NULL DEFAULT ''
+                    COMMENT 'Description of the change.',
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+                    COMMENT 'Date the change was deployed.',
+    committer_name  TEXT        NOT NULL
+                    COMMENT 'Name of the user who deployed the change.',
+    committer_email TEXT        NOT NULL
+                    COMMENT 'Email address of the user who deployed the change.',
+    planned_at      DATETIME64(6, 'UTC') NOT NULL
+                    COMMENT 'Date the change was added to the plan.',
+    planner_name    TEXT        NOT NULL
+                    COMMENT 'Name of the user who planed the change.',
+    planner_email   TEXT        NOT NULL
+                    COMMENT 'Email address of the user who planned the change.'
+) ENGINE = MergeTree
+  COMMENT 'Tracks the changes currently deployed to the database.';
+
+CREATE TABLE tags (
+    tag_id          TEXT        COMMENT 'Tag primary key.' PRIMARY KEY,
+    tag             TEXT        NOT NULL
+                    COMMENT 'Project-unique tag name.',
+    project         TEXT        NOT NULL
+                    COMMENT 'Name of the Sqitch project to which the tag belongs.',
+    change_id       TEXT        NOT NULL
+                    COMMENT 'ID of last change deployed before the tag was applied.',
+    note            TEXT        NOT NULL DEFAULT ''
+                    COMMENT 'Description of the tag.',
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+                    COMMENT 'Date the tag was applied to the database.',
+    committer_name  TEXT        NOT NULL
+                    COMMENT 'Name of the user who applied the tag.',
+    committer_email TEXT        NOT NULL
+                    COMMENT 'Email address of the user who applied the tag.',
+    planned_at      DATETIME64(6, 'UTC') NOT NULL
+                    COMMENT 'Date the tag was added to the plan.',
+    planner_name    TEXT        NOT NULL
+                    COMMENT 'Name of the user who planed the tag.',
+    planner_email   TEXT        NOT NULL
+                    COMMENT 'Email address of the user who planned the tag.'
+) ENGINE = MergeTree
+  COMMENT 'Tracks the tags currently applied to the database.';
+
+CREATE TABLE dependencies (
+    change_id       TEXT        NOT NULL
+                    COMMENT 'ID of the depending change.',
+    type            TEXT        NOT NULL
+                    COMMENT 'Type of dependency.',
+    dependency      TEXT        NOT NULL
+                    COMMENT 'Dependency name.',
+    dependency_id   TEXT            NULL
+                    COMMENT 'Change ID the dependency resolves to.',
+    CONSTRAINT dependencies_check CHECK (
+            (type = 'require'  AND dependency_id IS NOT NULL)
+         OR (type = 'conflict' AND dependency_id IS NULL)
+    )    
+) ENGINE = MergeTree
+  PRIMARY KEY (change_id, dependency)
+  COMMENT 'Tracks the tags currently applied to the database.';
+
+CREATE TABLE events (
+    event           TEXT        NOT NULL
+                    COMMENT 'Type of event.',
+    CONSTRAINT events_event_check CHECK (
+        event IN ('deploy', 'revert', 'fail', 'merge')
+    ),
+    change_id       TEXT                 NOT NULL
+                    COMMENT 'Change ID.',
+    change          TEXT                 NOT NULL
+                    COMMENT 'Change name.',
+    project         TEXT                 NOT NULL
+                    COMMENT 'Name of the Sqitch project to which the change belongs.',
+    note            TEXT                 NOT NULL DEFAULT ''
+                    COMMENT 'Description of the change.',
+    requires        Array(TEXT)          NOT NULL DEFAULT '[]'
+                    COMMENT 'Array of the names of required changes.',
+    conflicts       Array(TEXT)          NOT NULL DEFAULT '[]'
+                    COMMENT 'Array of the names of conflicting changes.',
+    tags            Array(TEXT)          NOT NULL DEFAULT '[]'
+                    COMMENT 'Tags associated with the change.',
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+                    COMMENT 'Date the event was committed.',
+    committer_name  TEXT                 NOT NULL
+                    COMMENT 'Name of the user who committed the event.',
+    committer_email TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who committed the event.',
+    planned_at      DATETIME64(6, 'UTC') NOT NULL
+                    COMMENT 'Date the event was added to the plan.',
+    planner_name    TEXT                 NOT NULL
+                    COMMENT 'Name of the user who planed the change.',
+    planner_email   TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who plan planned the change.',
+) ENGINE = MergeTree
+  PRIMARY KEY (committed_at, change_id)
+  COMMENT 'Contains full history of all deployment events.';

--- a/lib/App/Sqitch/Engine/clickhouse.sql
+++ b/lib/App/Sqitch/Engine/clickhouse.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE releases (
     version         REAL COMMENT 'Version of the Sqitch registry.' PRIMARY KEY,
-    installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+    installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the registry release was installed.',
     installer_name  TEXT                 NOT NULL
                     COMMENT 'Name of the user who installed the registry release.',
@@ -14,7 +14,7 @@ CREATE TABLE projects (
     project         TEXT        COMMENT 'Unique Name of a project.' PRIMARY KEY,
     uri             TEXT                 NULL
                     COMMENT 'Optional project URI',
-    created_at      DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+    created_at      DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the project was added to the database.',
     creator_name    TEXT                 NOT NULL
                     COMMENT 'Name of the user who added the project.',
@@ -33,7 +33,7 @@ CREATE TABLE changes (
                     COMMENT 'Name of the Sqitch project to which the change belongs.',
     note            TEXT        NOT NULL DEFAULT ''
                     COMMENT 'Description of the change.',
-    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the change was deployed.',
     committer_name  TEXT        NOT NULL
                     COMMENT 'Name of the user who deployed the change.',
@@ -58,7 +58,7 @@ CREATE TABLE tags (
                     COMMENT 'ID of last change deployed before the tag was applied.',
     note            TEXT        NOT NULL DEFAULT ''
                     COMMENT 'Description of the tag.',
-    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the tag was applied to the database.',
     committer_name  TEXT        NOT NULL
                     COMMENT 'Name of the user who applied the tag.',
@@ -110,7 +110,7 @@ CREATE TABLE events (
                     COMMENT 'Array of the names of conflicting changes.',
     tags            Array(TEXT)          NOT NULL DEFAULT '[]'
                     COMMENT 'Tags associated with the change.',
-    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT  now64(6, 'UTC')
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the event was committed.',
     committer_name  TEXT                 NOT NULL
                     COMMENT 'Name of the user who committed the event.',

--- a/lib/App/Sqitch/Engine/clickhouse.sql
+++ b/lib/App/Sqitch/Engine/clickhouse.sql
@@ -8,6 +8,7 @@ CREATE TABLE releases (
     installer_email TEXT                 NOT NULL
                     COMMENT 'Email address of the user who installed the registry release.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch registry releases.';
 
 CREATE TABLE projects (
@@ -21,6 +22,7 @@ CREATE TABLE projects (
     creator_email   TEXT                 NOT NULL
                     COMMENT 'Email address of the user who added the project.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch projects deployed to this database.';
 
 CREATE TABLE changes (
@@ -46,6 +48,7 @@ CREATE TABLE changes (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the change.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the changes currently deployed to the database.';
 
 CREATE TABLE tags (
@@ -71,6 +74,7 @@ CREATE TABLE tags (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the tag.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
 CREATE TABLE dependencies (
@@ -88,6 +92,7 @@ CREATE TABLE dependencies (
     )    
 ) ENGINE = MergeTree
   PRIMARY KEY (change_id, dependency)
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
 CREATE TABLE events (
@@ -124,4 +129,5 @@ CREATE TABLE events (
                     COMMENT 'Email address of the user who plan planned the change.',
 ) ENGINE = MergeTree
   PRIMARY KEY (committed_at, change_id)
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Contains full history of all deployment events.';

--- a/lib/sqitch-add.pod
+++ b/lib/sqitch-add.pod
@@ -128,7 +128,8 @@ be evaluated.
 This option allows one to define templates for specific tasks, such as
 creating a table, and then use them for changes that perform those tasks.
 Defaults to the name of the database engine (C<pg>, C<sqlite>, C<mysql>,
-C<oracle>, C<firebird>, C<vertica>, C<exasol>, or C<snowflake>).
+C<oracle>, C<firebird>, C<vertica>, C<exasol>, C<snowflake>, C<cockroach>, or
+C<clickhouse>).
 
 =item C<--use script=template>
 
@@ -358,8 +359,8 @@ The name of the change being added.
 =item C<engine>
 
 The name of the engine for which the change was added. One of C<pg>,
-C<sqlite>, C<mysql>, C<oracle>, C<firebird>, C<vertica> C<exasol>, or
-C<snowflake>.
+C<sqlite>, C<mysql>, C<oracle>, C<firebird>, C<vertica> C<exasol>,
+C<snowflake>, C<cockroach>, or C<clickhouse>).
 
 =item C<project>
 

--- a/lib/sqitch-authentication.pod
+++ b/lib/sqitch-authentication.pod
@@ -72,6 +72,10 @@ L<F<~/.snowsql/config> file|https://docs.snowflake.com/en/user-guide/snowsql-sta
 and use the default C<connections.username> value. Otherwise, it uses the
 system username.
 
+=item ClickHouse
+
+The ClickHouse engine uses the C<CLICKHOUSE_USER> environment variable, if set.
+
 =back
 
 =head1 Passwords
@@ -202,6 +206,11 @@ Sadly, both the C<SNOWSQL_PRIVATE_KEY_PASSPHRASE> environment variable and
 the C<priv_key_file_pwd> ODBC parameter must be set, as Sqitch uses ODBC to
 maintain its registry and SnowSQL to execute change scripts.
 
+=item ClickHouse
+
+The ClickHouse client supports passwordless authentication via an SSH key
+file. Sqitch does not currently support this feature.
+
 =back
 
 =head2 Use a Password File
@@ -330,6 +339,12 @@ The variables that Sqitch currently reads are:
 
 =back
 
+=item ClickHouse
+
+ClickHouse supports password configuration via its L<client configuration
+file|https://clickhouse.com/docs/interfaces/cli#connection-credentials>.
+Sqitch does not currently support this feature.
+
 =back
 
 =head2 Use C<$SQITCH_PASSWORD>
@@ -365,6 +380,10 @@ C<$ISC_PASSWORD>
 =item Snowflake
 
 C<$SNOWSQL_PWD>
+
+=item ClickHouse
+
+C<$CLICKHOUSE_PASSWORD>
 
 =back
 

--- a/lib/sqitch-checkout.pod
+++ b/lib/sqitch-checkout.pod
@@ -200,17 +200,13 @@ configuration values. Defaults to F<$top_dir/sqitch.plan>.
 =item C<[revert.variables]>
 
 A section defining database client variables. These variables are useful if
-your database engine supports variables in scripts, such as PostgreSQL's
-L<C<psql>
-variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
-Vertica's L<C<vsql>
-variables|https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/Variables.htm>,
-MySQL's L<user
-variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
-SQL*Plus's L<C<DEFINE>
-variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
-and Snowflake's L<SnowSQL
-variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>.
+your database engine supports variables in scripts, such as
+PostgreSQL's L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
+Vertica's L<C<vsql> variables|https://docs.vertica.com/24.2.x/en/connecting-to/using-vsql/variables/>,
+MySQL's L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
+SQL*Plus's L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
+Snowflake's L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>,
+and ClickHouse's L<queries with parameters|https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters>.
 
 May be overridden by C<--set>, C<--set-deploy>, C<--set-revert>, or target and
 engine configuration. Variables are merged in the following priority order:

--- a/lib/sqitch-config.pod
+++ b/lib/sqitch-config.pod
@@ -455,6 +455,8 @@ The database engine to use. Supported engines include:
 
 =item * C<cockroach> - L<CockroachDB|https://www.cockroachlabs.com/product/>
 
+=item * C<clickhouse> - L<ClickHouse|https://www.clickhouse.com/clickhouse/>
+
 =back
 
 =item C<core.top_dir>
@@ -611,6 +613,13 @@ C<sqitch>.
 For the Snowflake engine, the C<registry> value identifies the schema for
 Sqitch to use for its own data. No other data should be stored there. Defaults
 to C<sqitch>.
+
+=item C<engine.clickhouse.registry>
+
+For the ClickHouse engine, the C<registry> value identifies the database for
+Sqitch to use for its own data. If you need to manage multiple databases on a
+single server, and don't want them all to share the same registry, change this
+property to a value specific for your database. Defaults to C<sqitch>.
 
 =back
 

--- a/lib/sqitch-configuration.pod
+++ b/lib/sqitch-configuration.pod
@@ -142,7 +142,7 @@ the existing PostgreSQL stuff to a subdirectory.
 
   > mkdir pg
   > mv deploy revert verify sqitch.plan pg
-  > ls  pg  
+  > ls  pg
   deploy/ revert/ sqitch.plan verify/
 
 Now we need to tell Sqitch where things are. To create an engine-specific
@@ -794,17 +794,13 @@ following:
 =item C<variables>
 
 Database client variables. Useful if your database engine
-supports variables in scripts, such as PostgreSQL's
-L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
-Vertica's
-L<C<vsql> variables|https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/Variables.htm>
-MySQL's
-L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
-SQL*Plus's
-L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
-and Snowflake's
-L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>.
-To set variables, specify them via the following:
+supports variables in scripts, such as
+PostgreSQL's L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
+Vertica's L<C<vsql> variables|https://docs.vertica.com/24.2.x/en/connecting-to/using-vsql/variables/>,
+MySQL's L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
+SQL*Plus's L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
+Snowflake's L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>,
+and ClickHouse's L<queries with parameters|https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters>.
 
 =over
 

--- a/lib/sqitch-deploy.pod
+++ b/lib/sqitch-deploy.pod
@@ -197,16 +197,13 @@ Boolean indicating whether or not to verify each change.
 =item C<[deploy.variables]>
 
 A section defining database client variables. Useful if your database engine
-supports variables in scripts, such as PostgreSQL's
-L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
-Vertica's
-L<C<vsql> variables|https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/Variables.htm>
-MySQL's
-L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
-SQL*Plus's
-L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
-and Snowflake's
-L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>.
+supports variables in scripts, such as
+PostgreSQL's L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
+Vertica's L<C<vsql> variables|https://docs.vertica.com/24.2.x/en/connecting-to/using-vsql/variables/>,
+MySQL's L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
+SQL*Plus's L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
+Snowflake's L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>,
+and ClickHouse's L<queries with parameters|https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters>.
 
 May be overridden by C<--set> or target and engine configuration. Variables
 are merged in the following priority order:

--- a/lib/sqitch-engine.pod
+++ b/lib/sqitch-engine.pod
@@ -34,6 +34,10 @@ includes:
 
 =item * C<snowflake>
 
+=item * C<cockroach>
+
+=item * C<clickhouse>
+
 =back
 
 Each engine may have a number of properties:

--- a/lib/sqitch-environment.pod
+++ b/lib/sqitch-environment.pod
@@ -323,6 +323,29 @@ Snowflake.
 
 =back
 
+=head3 ClickHouse
+
+The Sqitch ClickHouse engine supports the following environment variables:
+
+=over
+
+=item C<CLICKHOUSE_USER>
+
+The username to use to connect to ClickHouse. Superseded by
+C<$SQITCH_USERNAME> and the target URI username.
+
+=item C<CLICKHOUSE_PASSWORD>
+
+The password to use to connect to Firebird. Superseded by C<$SQITCH_PASSWORD>
+and the target URI password.
+
+=item C<CLICKHOUSE_HOST>
+
+The ClickHouse server host to connect to. Superseded by the target URI host
+name.
+
+=back
+
 =head1 See Also
 
 =over

--- a/lib/sqitch-init.pod
+++ b/lib/sqitch-init.pod
@@ -55,6 +55,8 @@ include:
 
 =item * C<cockroach> - L<CockroachDB|https://www.cockroachlabs.com/product/>
 
+=item * C<clickhouse> - L<ClickHouse|https://www.clickhouse.com/clickhouse/>
+
 =back
 
 =item C<--top-dir>

--- a/lib/sqitch-rebase.pod
+++ b/lib/sqitch-rebase.pod
@@ -237,17 +237,13 @@ configuration values. Defaults to F<$top_dir/sqitch.plan>.
 =item C<[revert.variables]>
 
 A section defining database client variables. These variables are useful if
-your database engine supports variables in scripts, such as PostgreSQL's
-L<C<psql>
-variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
-Vertica's L<C<vsql>
-variables|https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/Variables.htm>,
-MySQL's L<user
-variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
-SQL*Plus's L<C<DEFINE>
-variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
-and Snowflake's L<SnowSQL
-variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>.
+your database engine supports variables in scripts, such as
+PostgreSQL's L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
+Vertica's L<C<vsql> variables|https://docs.vertica.com/24.2.x/en/connecting-to/using-vsql/variables/>,
+MySQL's L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
+SQL*Plus's L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
+Snowflake's L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>,
+and ClickHouse's L<queries with parameters|https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters>.
 
 May be overridden by C<--set>, C<--set-deploy>, C<--set-revert>, or target and
 engine configuration. Variables are merged in the following priority order:

--- a/lib/sqitch-revert.pod
+++ b/lib/sqitch-revert.pod
@@ -177,16 +177,13 @@ assumption that the values will generally be the same on revert. If they're
 not, use C<revert.variables> to override C<deploy.variables>.
 
 These variables are useful if your database engine supports variables in
-scripts, such as PostgreSQL's
-L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
-Vertica's
-L<C<vsql> variables|https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/Variables.htm>,
-MySQL's
-L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
-SQL*Plus's
-L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
-and Snowflake's
-L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>.
+scripts, such as
+PostgreSQL's L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
+Vertica's L<C<vsql> variables|https://docs.vertica.com/24.2.x/en/connecting-to/using-vsql/variables/>,
+MySQL's L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
+SQL*Plus's L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
+Snowflake's L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>,
+and ClickHouse's L<queries with parameters|https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters>.
 
 May be overridden by C<--set> or target and engine configuration. Variables
 are merged in the following priority order:

--- a/lib/sqitch-target.pod
+++ b/lib/sqitch-target.pod
@@ -38,6 +38,8 @@ Some examples:
 
 =item C<db:firebird://localhost//tmp/test.fdb>
 
+=item C<db:clickhouse://default@localhost/default?Driver=ClickHouse>
+
 =back
 
 Note that, as with any URI or URL, special characters must be

--- a/lib/sqitch-verify.pod
+++ b/lib/sqitch-verify.pod
@@ -178,16 +178,13 @@ assumption that the values will generally be the same on verify. If they're
 not, use C<verify.variables> to override C<deploy.variables>.
 
 These variables are useful if your database engine supports variables in
-scripts, such as PostgreSQL's
-L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
-Vertica's
-L<C<vsql> variables|https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/Variables.htm>,
-MySQL's
-L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
-SQL*Plus's
-L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
-and Snowflake's
-L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>.
+scripts, such as
+PostgreSQL's L<C<psql> variables|https://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-INTERPOLATION>,
+Vertica's L<C<vsql> variables|https://docs.vertica.com/24.2.x/en/connecting-to/using-vsql/variables/>,
+MySQL's L<user variables|https://dev.mysql.com/doc/refman/5.6/en/user-variables.html>,
+SQL*Plus's L<C<DEFINE> variables|https://docs.oracle.com/cd/B19306_01/server.102/b14357/ch12017.htm>,
+Snowflake's L<SnowSQL variables|https://docs.snowflake.com/en/user-guide/snowsql-use.html#using-variables>,
+and ClickHouse's L<queries with parameters|https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters>.
 
 May be overridden by C<--set> or target and engine configuration. Variables
 are merged in the following priority order:

--- a/lib/sqitch.pod
+++ b/lib/sqitch.pod
@@ -36,6 +36,8 @@ Sqitch is a database change management application. It currently supports:
 
 =item * L<Snowflake|https://www.snowflake.net/>
 
+=item * L<ClickHouse|https://www.clickhouse.com/clickhouse/> 24+
+
 =back
 
 What makes it different from your typical

--- a/t/clickhouse.t
+++ b/t/clickhouse.t
@@ -1,0 +1,465 @@
+#!/usr/bin/perl -w
+
+# To test against a live ClickHouse database, you must set the
+# SQITCH_TEST_CLICKHOUSE_URI environment variable. this is a standard URI::db
+# URI, and should look something like this:
+#
+#     export SQITCH_TEST_CLICKHOUSE_URI=db:clickhouse://default@localhost/default?DSN=Clickhouse
+#
+
+use strict;
+use warnings;
+use 5.010;
+use Test::More;
+use App::Sqitch;
+use App::Sqitch::Target;
+use Test::File::Contents;
+use Test::MockModule;
+use Path::Class;
+use Try::Tiny;
+use Test::Exception;
+use List::MoreUtils qw(firstidx);
+use Locale::TextDomain qw(App-Sqitch);
+use File::Temp 'tempdir';
+use DBD::Mem;
+use lib 't/lib';
+use DBIEngineTest;
+use TestConfig;
+
+my $CLASS;
+
+BEGIN {
+    $CLASS = 'App::Sqitch::Engine::clickhouse';
+    require_ok $CLASS or die;
+    delete $ENV{$_} for grep { /^CLICKHOUSE_/ } keys %ENV;
+}
+
+is_deeply [$CLASS->config_vars], [
+    target   => 'any',
+    registry => 'any',
+    client   => 'any',
+], 'config_vars should return three vars';
+
+my $uri = URI::db->new('db:clickhouse:default');
+my $config = TestConfig->new(
+    'core.engine' => 'clickhouse',
+    'engine.clickhouse.target' => $uri->as_string,
+);
+my $sqitch = App::Sqitch->new(config => $config);
+my $target = App::Sqitch::Target->new(sqitch => $sqitch);
+isa_ok my $ch = $CLASS->new(sqitch => $sqitch, target => $target), $CLASS;
+
+is $ch->key, 'clickhouse', 'Key should be "clickhouse"';
+is $ch->name, 'ClickHouse', 'Name should be "ClickHouse"';
+
+my $client = 'clickhouse-client' . (App::Sqitch::ISWIN ? '.exe' : '');
+is $ch->client, $client, 'client should default to clickhouse';
+is $ch->registry, 'sqitch', 'registry default should be "sqitch"';
+my $sqitch_uri = $uri->clone;
+$sqitch_uri->dbname('sqitch');
+is $ch->registry_uri, $sqitch_uri, 'registry_uri should be correct';
+is $ch->uri, $uri, qq{uri should be "$uri"};
+is $ch->_dsn, 'dbi:ODBC:DSN=default', 'DSN should use DBD::ODBC';
+is $ch->registry_destination, 'db:clickhouse:sqitch',
+    'registry_destination should be the same as registry_uri';
+
+my @std_opts = (
+    '--progress' => 'off',
+    '--progress-table' => 'off',
+    '--disable_suggestion',
+);
+
+my $mock_sqitch = Test::MockModule->new('App::Sqitch');
+my $warning;
+$mock_sqitch->mock(warn => sub { shift; $warning = [@_] });
+$ch->uri->dbname('');
+is_deeply [$ch->cli], [$client, '--user', $sqitch->sysuser, @std_opts],
+    'clickhouse command should be user and std opts-only';
+is_deeply $warning, [__x
+    'Database name missing in URI "{uri}"',
+     uri => $ch->uri
+], 'Should have emitted a warning for no database name';
+
+
+
+$mock_sqitch->unmock_all;
+
+$target = App::Sqitch::Target->new(
+    sqitch => $sqitch,
+    uri => URI::db->new('db:clickhouse:foo'),
+);
+isa_ok $ch = $CLASS->new(
+    sqitch => $sqitch,
+    target => $target,
+), $CLASS;
+
+##############################################################################
+# Make sure environment variables are read.
+ENV: {
+    local $ENV{CLICKHOUSE_USER} = 'kamala';
+    local $ENV{CLICKHOUSE_PASSWORD} = '__KAMALA';
+    ok my $ch = $CLASS->new(sqitch => $sqitch, target => $target),
+        'Create engine with env vars set set';
+    is $ch->password, $ENV{CLICKHOUSE_PASSWORD},
+        'Password should be set from environment';
+    is $ch->username, $ENV{CLICKHOUSE_USER},
+        'Username should be set from environment';
+}
+
+##############################################################################
+# Make sure config settings override defaults and the password is set or removed
+# as appropriate.
+$config->update(
+    'engine.clickhouse.client'   => '/path/to/clickhouse',
+    'engine.clickhouse.target'   => 'db:clickhouse://me:pwd@foo.com/widgets',
+    'engine.clickhouse.registry' => 'meta',
+);
+# my $ch_version = 'clickhouse  Ver 15.1 Distrib 10.0.15-MariaDB';
+# $mock_sqitch->mock(probe => sub { $ch_version });
+# push @std_opts => '--abort-source-on-error'
+#     unless $std_opts[-1] eq '--abort-source-on-error';
+
+$target = App::Sqitch::Target->new(sqitch => $sqitch);
+ok $ch = $CLASS->new(sqitch => $sqitch, target => $target),
+    'Create another clickhouse';
+is $ch->client, '/path/to/clickhouse', 'client should be as configured';
+is $ch->uri->as_string, 'db:clickhouse://me:pwd@foo.com/widgets',
+    'URI should be as configured';
+like $ch->target->name, qr{^db:clickhouse://me:?\@foo\.com/widgets$},
+    'target name should be the URI without the password';
+like $ch->destination, qr{^db:clickhouse://me:?\@foo\.com/widgets$},
+    'destination should be the URI without the password';
+is $ch->registry, 'meta', 'registry should be as configured';
+is $ch->registry_uri->as_string, 'db:clickhouse://me:pwd@foo.com/meta',
+    'Sqitch DB URI should be the same as uri but with DB name "meta"';
+like $ch->registry_destination, qr{^db:clickhouse://me:?\@foo\.com/meta$},
+    'registry_destination should be the sqitch DB URL without the password';
+is_deeply [$ch->cli], [
+    '/path/to/clickhouse',
+    'client',
+    '--user',     'me',
+    '--password', 'pwd',
+    '--database', 'widgets',
+    '--host',     'foo.com',
+    @std_opts
+], 'clickhouse command should be configured';
+
+##############################################################################
+# Make sure URI params get passed through to the client.
+$target = App::Sqitch::Target->new(
+    sqitch => $sqitch,
+    uri    => URI->new('db:clickhouse://foo.com/widgets?SSLMode=require',
+));
+ok $ch = $CLASS->new(sqitch => $sqitch, target => $target),
+    'Create a clickhouse with query params';
+is_deeply [$ch->cli], [
+    qw(/path/to/clickhouse client),
+    '--user', $sqitch->sysuser,
+    qw(--database widgets --host foo.com),
+    @std_opts,
+    '--secure',
+], 'clickhouse command should be configured with query vals';
+
+##############################################################################
+# Test _run(), _capture(), and _spool().
+can_ok $ch, qw(_run _capture _spool);
+my $pass_env_name = 'CLICKHOUSE_PASSWORD';
+my (@run, $exp_pass);
+$mock_sqitch->mock(run => sub {
+    local $Test::Builder::Level = $Test::Builder::Level + 2;
+    shift;
+    @run = @_;
+    if (defined $exp_pass) {
+        is $ENV{$pass_env_name}, $exp_pass, qq{$pass_env_name should be "$exp_pass"};
+    } else {
+        ok !exists $ENV{$pass_env_name}, '$pass_env_name should not exist';
+    }
+});
+
+my @capture;
+$mock_sqitch->mock(capture => sub {
+    local $Test::Builder::Level = $Test::Builder::Level + 2;
+    shift;
+    @capture = @_;
+    if (defined $exp_pass) {
+        is $ENV{$pass_env_name}, $exp_pass, qq{$pass_env_name should be "$exp_pass"};
+    } else {
+        ok !exists $ENV{$pass_env_name}, '$pass_env_name should not exist';
+    }
+});
+
+my @spool;
+$mock_sqitch->mock(spool => sub {
+    local $Test::Builder::Level = $Test::Builder::Level + 2;
+    shift;
+    @spool = @_;
+    if (defined $exp_pass) {
+        is $ENV{$pass_env_name}, $exp_pass, qq{$pass_env_name should be "$exp_pass"};
+    } else {
+        ok !exists $ENV{$pass_env_name}, '$pass_env_name should not exist';
+    }
+});
+
+$target = App::Sqitch::Target->new(sqitch => $sqitch);
+ok $ch = $CLASS->new(sqitch => $sqitch, target => $target),
+    'Create a clickhouse with sqitch with options';
+$exp_pass = 's3cr3t';
+$target->uri->password($exp_pass);
+ok $ch->_run(qw(foo bar baz)), 'Call _run';
+is_deeply \@run, [$ch->cli, qw(foo bar baz)],
+    'Command should be passed to run()';
+
+ok $ch->_spool('FH'), 'Call _spool';
+is_deeply \@spool, [['FH'], $ch->cli],
+    'Command should be passed to spool()';
+
+ok $ch->_capture(qw(foo bar baz)), 'Call _capture';
+is_deeply \@capture, [$ch->cli, qw(foo bar baz)],
+    'Command should be passed to capture()';
+
+# Without password.
+$target = App::Sqitch::Target->new( sqitch => $sqitch );
+ok $ch = $CLASS->new(sqitch => $sqitch, target => $target),
+    'Create a clickhouse with sqitch with no pw';
+$exp_pass = undef;
+$target->uri->password($exp_pass);
+ok $ch->_run(qw(foo bar baz)), 'Call _run again';
+is_deeply \@run, [$ch->cli, qw(foo bar baz)],
+    'Command should be passed to run() again';
+
+ok $ch->_spool('FH'), 'Call _spool again';
+is_deeply \@spool, [['FH'], $ch->cli],
+    'Command should be passed to spool() again';
+
+ok $ch->_capture(qw(foo bar baz)), 'Call _capture again';
+is_deeply \@capture, [$ch->cli, qw(foo bar baz)],
+    'Command should be passed to capture() again';
+
+##############################################################################
+# Test file and handle running.
+ok $ch->run_file('foo/bar.sql'), 'Run foo/bar.sql';
+is_deeply \@run, [$ch->cli, '--query-file', 'foo/bar.sql'],
+    'File should be passed to run()';
+@run = ();
+
+ok $ch->run_handle('FH'), 'Spool a "file handle"';
+is_deeply \@spool, [['FH'], $ch->cli],
+    'Handle should be passed to spool()';
+@spool = ();
+
+# Verify should go to capture unless verbosity is > 1.
+ok $ch->run_verify('foo/bar.sql'), 'Verify foo/bar.sql';
+is_deeply \@capture, [$ch->cli, '--query-file', 'foo/bar.sql'],
+    'Verify file should be passed to capture()';
+@capture = ();
+
+$mock_sqitch->mock(verbosity => 2);
+ok $ch->run_verify('foo/bar.sql'), 'Verify foo/bar.sql again';
+is_deeply \@run, [$ch->cli, '--query-file', 'foo/bar.sql'],
+    'Verify file should be passed to run() for high verbosity';
+@run = ();
+
+$ch->clear_variables;
+$mock_sqitch->unmock_all;
+
+##############################################################################
+# Test DateTime formatting stuff.
+can_ok $CLASS, '_ts2char_format';
+is sprintf($CLASS->_ts2char_format, 'foo'),
+    q{formatDateTime(foo, 'year:%Y:month:%m:day:%d:hour:%H:minute:%i:second:%S:time_zone:UTC')},
+    '_ts2char_format should work';
+
+ok my $dtfunc = $CLASS->can('_dt'), "$CLASS->can('_dt')";
+isa_ok my $dt = $dtfunc->(
+    'year:2012:month:07:day:05:hour:15:minute:07:second:01:time_zone:UTC'
+), 'App::Sqitch::DateTime', 'Return value of _dt()';
+is $dt->year, 2012, 'DateTime year should be set';
+is $dt->month,   7, 'DateTime month should be set';
+is $dt->day,     5, 'DateTime day should be set';
+is $dt->hour,   15, 'DateTime hour should be set';
+is $dt->minute,  7, 'DateTime minute should be set';
+is $dt->second,  1, 'DateTime second should be set';
+is $dt->time_zone->name, 'UTC', 'DateTime TZ should be set';
+
+##############################################################################
+# Test SQL helpers.
+is $ch->_listagg_format, q{groupArraySorted(10000)(%1$s)},
+    'Should have _listagg_format';
+is $ch->_regex_op, 'REGEXP', 'Should have _regex_op';
+is $ch->_simple_from, '', 'Should have _simple_from';
+is $ch->_limit_default, undef, 'Should have no _limit_default';
+
+is $ch->_ts_default, q{now64(6, 'UTC')},
+    'Should have _ts_default with now64()';
+
+DBI: {
+    local *DBI::state;
+    ok !$ch->_no_table_error, 'Should have no table error';
+    ok !$ch->_no_column_error, 'Should have no column error';
+    $DBI::state = '42S02';
+    ok $ch->_no_table_error, 'Should now have table error';
+    ok !$ch->_no_column_error, 'Still should have no column error';
+    $DBI::state = '42703';
+    ok !$ch->_no_table_error, 'Should again have no table error';
+    ok $ch->_no_column_error, 'Should now have no column error';
+    ok !$ch->_unique_error, 'Unique constraints not supported by Snowflake';
+}
+
+
+is_deeply [$ch->_limit_offset(8, 4)],
+    [['LIMIT ?', 'OFFSET ?'], [8, 4]],
+    'Should get limit and offset';
+is_deeply [$ch->_limit_offset(0, 2)], [['OFFSET ?'], [2]],
+    'Should get limit and offset when offset only';
+is_deeply [$ch->_limit_offset(12, 0)], [['LIMIT ?'], [12]],
+    'Should get only limit with 0 offset';
+is_deeply [$ch->_limit_offset(12)], [['LIMIT ?'], [12]],
+    'Should get only limit with noa offset';
+is_deeply [$ch->_limit_offset(0, 0)], [[], []],
+    'Should get no limit or offset for 0s';
+is_deeply [$ch->_limit_offset()], [[], []],
+    'Should get no limit or offset for no args';
+
+is_deeply [$ch->_regex_expr('corn', 'Obama$')],
+    ['corn REGEXP ?', 'Obama$'],
+    'Should use REGEXP for regex expr';
+
+##############################################################################
+# Test unexpected database error in initialized() and _cid().
+MOCKDBH: {
+    my $mock = Test::MockModule->new($CLASS);
+    $mock->mock(dbh => sub { die 'OW' });
+    throws_ok { $ch->initialized } qr/OW/,
+        'initialized() should rethrow unexpected DB error';
+    throws_ok { $ch->_cid } qr/OW/,
+        '_cid should rethrow unexpected DB error';
+}
+
+##############################################################################
+# Test run_upgrade().
+UPGRADE: {
+    my $mock = Test::MockModule->new($CLASS);
+    my $fracsec;
+    my $version = 50500;
+    $mock->mock(_fractional_seconds => sub { $fracsec });
+    $mock->mock(dbh => sub { { mariadb_serverversion => $version } });
+    $mock->mock(_create_check_function => 1);
+
+    # Mock run.
+    my @run;
+    $mock_sqitch->mock(run => sub { shift; @run = @_ });
+
+    # Mock File::Temp so we hang on to the file.
+    my $mock_ft = Test::MockModule->new('File::Temp');
+    my $tmp_fh;
+    my $ft_new;
+    $mock_ft->mock(new => sub { $tmp_fh = 'File::Temp'->$ft_new() });
+    $ft_new = $mock_ft->original('new');
+
+    # Assemble the expected command.
+    my @cmd = $ch->cli;
+    my $db_opt_idx = firstidx { $_ eq '--database' } @cmd;
+    $cmd[$db_opt_idx + 1] = $ch->registry;
+    my $fn = file($INC{'App/Sqitch/Engine/clickhouse.pm'})->dir->file('clickhouse.sql');
+
+    # Test the upgrade.
+    ok $ch->run_upgrade($fn), 'Run the upgrade';
+    is $tmp_fh, undef, 'Should not have created a temp file';
+    is_deeply \@run, [@cmd, '--query-file', $fn],
+        'It should have run the unchanged file';
+
+    $mock_sqitch->unmock_all;
+}
+
+# Make sure we have templates.
+DBIEngineTest->test_templates_for($ch->key);
+
+##############################################################################
+# Can we do live tests?
+my $dbh;
+my $id = DBIEngineTest->randstr;
+my ($db, $reg1, $reg2) = map { $_ . $id } qw(__sqitchtest__ __metasqitch __sqitchtest);
+
+END {
+    return unless $dbh;
+    $dbh->{Driver}->visit_child_handles(sub {
+        my $h = shift;
+        $h->disconnect if $h->{Type} eq 'db' && $h->{Active} && $h ne $dbh;
+    });
+
+    return unless $dbh->{Active};
+    $dbh->do("DROP DATABASE IF EXISTS $_") for ($db, $reg1, $reg2);
+}
+
+$uri = URI->new(
+    $ENV{SQITCH_TEST_CLICKHOUSE_URI} ||
+    'db:clickhouse://default@localhost/default?Driver=ClickHouse'
+);
+$uri->dbname('default') unless $uri->dbname;
+my $err = try {
+    $ch->use_driver;
+    $dbh = DBI->connect($uri->dbi_dsn, $uri->user, $uri->password, {
+        PrintError  => 0,
+        RaiseError  => 0,
+        AutoCommit  => 1,
+        HandleError => $ch->error_handler,
+    });
+
+    $dbh->do("CREATE DATABASE $db");
+    $uri->dbname($db);
+    undef;
+} catch {
+    $_
+};
+
+DBIEngineTest->run(
+    class             => $CLASS,
+    target_params     => [ registry => $reg1, uri => $uri ],
+    alt_target_params => [ registry => $reg2, uri => $uri ],
+    skip_unless       => sub {
+        my $self = shift;
+        die $err if $err;
+        # Make sure we have clickhouse and can connect to the database.
+        my $version = $self->sqitch->capture( $self->client, '--version' );
+        say "# Detected CLI $version";
+        say '# Connected to ClickHouse ' . $self->_capture('--execute' => 'SELECT version()');
+        1;
+    },
+    engine_err_regex  => qr/^You have an error /,
+    init_error        => __x(
+        'Sqitch database {database} already initialized',
+        database => $reg2,
+    ),
+    test_dbh => sub {
+        my $dbh = shift;
+        # Special-case sql_mode.
+        my $sql_mode = $dbh->selectcol_arrayref('SELECT @@SESSION.sql_mode')->[0];
+        for my $mode (qw(
+                ansi
+                strict_trans_tables
+                no_auto_value_on_zero
+                no_zero_date
+                no_zero_in_date
+                only_full_group_by
+                error_for_division_by_zero
+        )) {
+            like $sql_mode, qr/\b\Q$mode\E\b/i, "sql_mode should include $mode";
+        }
+    },
+        lock_sql => sub {
+            my $lock_name = shift->_lock_name; return {
+            is_locked  => "SELECT is_used_lock('$lock_name')",
+            try_lock   => "SELECT get_lock('$lock_name', 0)",
+            wait_time  => 1, # get_lock() does not support sub-second precision, apparently.
+            async_free => 1,
+            free_lock  => 'SELECT ' . ($dbh ? do {
+                # ClickHouse 5.5-5.6 and Maria 10.0-10.4 prefer release_lock(), while
+                # 5.7+ and 10.5+ prefer release_all_locks().
+                $dbh->selectrow_arrayref('SELECT version()')->[0] =~ /^(?:5\.[56]|10\.[0-4])/
+                    ? "release_lock('$lock_name')"
+                    : 'release_all_locks()'
+            } : ''),
+        } },
+);
+
+done_testing;

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -1890,7 +1890,7 @@ sub run {
 
         ######################################################################
         # Let's make sure script_hash upgrades work.
-        $engine->dbh->do('UPDATE changes SET script_hash = change_id');
+        $engine->dbh->do('UPDATE changes SET script_hash = change_id WHERE 1=1');
         ok $engine->_update_script_hashes, 'Update script hashes';
 
         # Make sure they were updated properly.

--- a/t/lib/DBIEngineTest.pm
+++ b/t/lib/DBIEngineTest.pm
@@ -597,7 +597,7 @@ sub run {
         ]], 'The tag should be the same';
 
         # Delete that tag.
-        $engine->dbh->do('DELETE FROM tags');
+        $engine->dbh->do('DELETE FROM tags WHERE 1=1');
         is_deeply all_tags($engine), [], 'Should now have no tags';
 
         # Put it back.
@@ -748,7 +748,7 @@ sub run {
         ok $req->resolved_id($change->id),      'Set resolved ID in required depend';
         # Send this change back in time.
         $engine->dbh->do(
-            'UPDATE changes SET committed_at = ?',
+            'UPDATE changes SET committed_at = ? WHERE 1=1',
                 undef, '2013-03-30 00:47:47',
         );
         ok $engine->log_deploy_change($change2),    'Deploy second change';

--- a/t/lib/upgradable_registries/clickhouse.sql
+++ b/t/lib/upgradable_registries/clickhouse.sql
@@ -1,0 +1,122 @@
+
+CREATE TABLE releases (
+    version         REAL COMMENT 'Version of the Sqitch registry.' PRIMARY KEY,
+    installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
+                    COMMENT 'Date the registry release was installed.',
+    installer_name  TEXT                 NOT NULL
+                    COMMENT 'Name of the user who installed the registry release.',
+    installer_email TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who installed the registry release.'
+) ENGINE = MergeTree
+  COMMENT 'Sqitch registry releases.';
+
+CREATE TABLE projects (
+    project         TEXT        COMMENT 'Unique Name of a project.' PRIMARY KEY,
+    uri             TEXT                 NULL
+                    COMMENT 'Optional project URI',
+    created_at      DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
+                    COMMENT 'Date the project was added to the database.',
+    creator_name    TEXT                 NOT NULL
+                    COMMENT 'Name of the user who added the project.',
+    creator_email   TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who added the project.'
+) ENGINE = MergeTree
+  COMMENT 'Sqitch projects deployed to this database.';
+
+CREATE TABLE changes (
+    change_id       TEXT        COMMENT 'Change primary key.' PRIMARY KEY,
+    change          TEXT        NOT NULL
+                    COMMENT 'Name of a deployed change.',
+    project         TEXT        NOT NULL
+                    COMMENT 'Name of the Sqitch project to which the change belongs.',
+    note            TEXT        NOT NULL DEFAULT ''
+                    COMMENT 'Description of the change.',
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
+                    COMMENT 'Date the change was deployed.',
+    committer_name  TEXT        NOT NULL
+                    COMMENT 'Name of the user who deployed the change.',
+    committer_email TEXT        NOT NULL
+                    COMMENT 'Email address of the user who deployed the change.',
+    planned_at      DATETIME64(6, 'UTC') NOT NULL
+                    COMMENT 'Date the change was added to the plan.',
+    planner_name    TEXT        NOT NULL
+                    COMMENT 'Name of the user who planed the change.',
+    planner_email   TEXT        NOT NULL
+                    COMMENT 'Email address of the user who planned the change.'
+) ENGINE = MergeTree
+  COMMENT 'Tracks the changes currently deployed to the database.';
+
+CREATE TABLE tags (
+    tag_id          TEXT        COMMENT 'Tag primary key.' PRIMARY KEY,
+    tag             TEXT        NOT NULL
+                    COMMENT 'Project-unique tag name.',
+    project         TEXT        NOT NULL
+                    COMMENT 'Name of the Sqitch project to which the tag belongs.',
+    change_id       TEXT        NOT NULL
+                    COMMENT 'ID of last change deployed before the tag was applied.',
+    note            TEXT        NOT NULL DEFAULT ''
+                    COMMENT 'Description of the tag.',
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
+                    COMMENT 'Date the tag was applied to the database.',
+    committer_name  TEXT        NOT NULL
+                    COMMENT 'Name of the user who applied the tag.',
+    committer_email TEXT        NOT NULL
+                    COMMENT 'Email address of the user who applied the tag.',
+    planned_at      DATETIME64(6, 'UTC') NOT NULL
+                    COMMENT 'Date the tag was added to the plan.',
+    planner_name    TEXT        NOT NULL
+                    COMMENT 'Name of the user who planed the tag.',
+    planner_email   TEXT        NOT NULL
+                    COMMENT 'Email address of the user who planned the tag.'
+) ENGINE = MergeTree
+  COMMENT 'Tracks the tags currently applied to the database.';
+
+CREATE TABLE dependencies (
+    change_id       TEXT        NOT NULL
+                    COMMENT 'ID of the depending change.',
+    type            TEXT        NOT NULL
+                    COMMENT 'Type of dependency.',
+    dependency      TEXT        NOT NULL
+                    COMMENT 'Dependency name.',
+    dependency_id   TEXT            NULL
+                    COMMENT 'Change ID the dependency resolves to.',
+    CONSTRAINT dependencies_check CHECK (
+            (type = 'require'  AND dependency_id IS NOT NULL)
+         OR (type = 'conflict' AND dependency_id IS NULL)
+    )    
+) ENGINE = MergeTree
+  PRIMARY KEY (change_id, dependency)
+  COMMENT 'Tracks the tags currently applied to the database.';
+
+CREATE TABLE events (
+    event           TEXT        NOT NULL
+                    COMMENT 'Type of event.',
+    change_id       TEXT                 NOT NULL
+                    COMMENT 'Change ID.',
+    change          TEXT                 NOT NULL
+                    COMMENT 'Change name.',
+    project         TEXT                 NOT NULL
+                    COMMENT 'Name of the Sqitch project to which the change belongs.',
+    note            TEXT                 NOT NULL DEFAULT ''
+                    COMMENT 'Description of the change.',
+    requires        Array(TEXT)          NOT NULL DEFAULT '[]'
+                    COMMENT 'Array of the names of required changes.',
+    conflicts       Array(TEXT)          NOT NULL DEFAULT '[]'
+                    COMMENT 'Array of the names of conflicting changes.',
+    tags            Array(TEXT)          NOT NULL DEFAULT '[]'
+                    COMMENT 'Tags associated with the change.',
+    committed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
+                    COMMENT 'Date the event was committed.',
+    committer_name  TEXT                 NOT NULL
+                    COMMENT 'Name of the user who committed the event.',
+    committer_email TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who committed the event.',
+    planned_at      DATETIME64(6, 'UTC') NOT NULL
+                    COMMENT 'Date the event was added to the plan.',
+    planner_name    TEXT                 NOT NULL
+                    COMMENT 'Name of the user who planed the change.',
+    planner_email   TEXT                 NOT NULL
+                    COMMENT 'Email address of the user who plan planned the change.',
+) ENGINE = MergeTree
+  PRIMARY KEY (committed_at, change_id)
+  COMMENT 'Contains full history of all deployment events.';

--- a/t/lib/upgradable_registries/clickhouse.sql
+++ b/t/lib/upgradable_registries/clickhouse.sql
@@ -8,6 +8,7 @@ CREATE TABLE releases (
     installer_email TEXT                 NOT NULL
                     COMMENT 'Email address of the user who installed the registry release.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch registry releases.';
 
 CREATE TABLE projects (
@@ -21,6 +22,7 @@ CREATE TABLE projects (
     creator_email   TEXT                 NOT NULL
                     COMMENT 'Email address of the user who added the project.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch projects deployed to this database.';
 
 CREATE TABLE changes (
@@ -44,6 +46,7 @@ CREATE TABLE changes (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the change.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the changes currently deployed to the database.';
 
 CREATE TABLE tags (
@@ -69,6 +72,7 @@ CREATE TABLE tags (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the tag.'
 ) ENGINE = MergeTree
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
 CREATE TABLE dependencies (
@@ -86,6 +90,7 @@ CREATE TABLE dependencies (
     )    
 ) ENGINE = MergeTree
   PRIMARY KEY (change_id, dependency)
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
 CREATE TABLE events (
@@ -119,4 +124,5 @@ CREATE TABLE events (
                     COMMENT 'Email address of the user who plan planned the change.',
 ) ENGINE = MergeTree
   PRIMARY KEY (committed_at, change_id)
+  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Contains full history of all deployment events.';

--- a/t/lib/upgradable_registries/clickhouse.sql
+++ b/t/lib/upgradable_registries/clickhouse.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE releases (
-    version         REAL COMMENT 'Version of the Sqitch registry.' PRIMARY KEY,
+    version         REAL                 NOT NULL
+                    COMMENT 'Version of the Sqitch registry.',
     installed_at    DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
                     COMMENT 'Date the registry release was installed.',
     installer_name  TEXT                 NOT NULL
@@ -8,11 +9,14 @@ CREATE TABLE releases (
     installer_email TEXT                 NOT NULL
                     COMMENT 'Email address of the user who installed the registry release.'
 ) ENGINE = MergeTree
+  PRIMARY KEY version
+  ORDER BY version
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch registry releases.';
 
 CREATE TABLE projects (
-    project         TEXT        COMMENT 'Unique Name of a project.' PRIMARY KEY,
+    project         TEXT                 NOT NULL
+                    COMMENT 'Unique Name of a project.',
     uri             TEXT                 NULL
                     COMMENT 'Optional project URI',
     created_at      DATETIME64(6, 'UTC') NOT NULL DEFAULT now64(6, 'UTC')
@@ -22,11 +26,14 @@ CREATE TABLE projects (
     creator_email   TEXT                 NOT NULL
                     COMMENT 'Email address of the user who added the project.'
 ) ENGINE = MergeTree
+  PRIMARY KEY project
+  ORDER BY project
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Sqitch projects deployed to this database.';
 
 CREATE TABLE changes (
-    change_id       TEXT        COMMENT 'Change primary key.' PRIMARY KEY,
+    change_id       TEXT        NOT NULL
+                    COMMENT 'Change primary key.',
     change          TEXT        NOT NULL
                     COMMENT 'Name of a deployed change.',
     project         TEXT        NOT NULL
@@ -46,11 +53,14 @@ CREATE TABLE changes (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the change.'
 ) ENGINE = MergeTree
+  PRIMARY KEY (project, change_id)
+  ORDER BY (project, change_id)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the changes currently deployed to the database.';
 
 CREATE TABLE tags (
-    tag_id          TEXT        COMMENT 'Tag primary key.' PRIMARY KEY,
+    tag_id          TEXT        NOT NULL
+                    COMMENT 'Tag primary key.',
     tag             TEXT        NOT NULL
                     COMMENT 'Project-unique tag name.',
     project         TEXT        NOT NULL
@@ -72,6 +82,8 @@ CREATE TABLE tags (
     planner_email   TEXT        NOT NULL
                     COMMENT 'Email address of the user who planned the tag.'
 ) ENGINE = MergeTree
+  PRIMARY KEY (project, change_id, tag_id)
+  ORDER BY (project, change_id, tag_id)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
@@ -90,11 +102,12 @@ CREATE TABLE dependencies (
     )    
 ) ENGINE = MergeTree
   PRIMARY KEY (change_id, dependency)
+  ORDER BY (change_id, dependency)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Tracks the tags currently applied to the database.';
 
 CREATE TABLE events (
-    event           TEXT        NOT NULL
+    event           TEXT                 NOT NULL
                     COMMENT 'Type of event.',
     change_id       TEXT                 NOT NULL
                     COMMENT 'Change ID.',
@@ -123,6 +136,7 @@ CREATE TABLE events (
     planner_email   TEXT                 NOT NULL
                     COMMENT 'Email address of the user who plan planned the change.',
 ) ENGINE = MergeTree
-  PRIMARY KEY (committed_at, change_id)
+  PRIMARY KEY (project, committed_at)
+  ORDER BY (project, committed_at)
   SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
   COMMENT 'Contains full history of all deployment events.';

--- a/t/odbc/clickhouse.ini
+++ b/t/odbc/clickhouse.ini
@@ -1,5 +1,0 @@
-[ODBC Data Sources]
-ClickHouse = ClickHouse
-
-[ClickHouse]
-Driver = /opt/clickhouse/lib/libSnowflake.so

--- a/t/odbc/clickhouse.ini
+++ b/t/odbc/clickhouse.ini
@@ -1,0 +1,5 @@
+[ODBC Data Sources]
+ClickHouse = ClickHouse
+
+[ClickHouse]
+Driver = /opt/clickhouse/lib/libSnowflake.so

--- a/t/odbc/odbcinst.ini
+++ b/t/odbc/odbcinst.ini
@@ -9,3 +9,7 @@ Driver      = /opt/vertica/lib64/libverticaodbc.so
 [Snowflake]
 Description = ODBC for Snowflake
 Driver      = /opt/snowflake/lib/libSnowflake.so
+
+[ClickHouse]
+Description = ODBC for ClickHouse
+Driver      = /opt/clickhouse/lib/libclickhouseodbcw.so

--- a/xt/release/pod-spelling.t
+++ b/xt/release/pod-spelling.t
@@ -17,6 +17,7 @@ API
 Blockchain
 blog
 change's
+ClickHouse
 CLDR
 CockroachDB
 command's
@@ -101,6 +102,7 @@ sql
 SQLite
 sqlite
 SQLite's
+SSLMode
 subdirectories
 sublicense
 Suciu


### PR DESCRIPTION
# 📢❗🚨New engine! New engine! New engine!

The ClickHouse engine is based on the Snowflake, MySQL, and Exasol implementations. Like Snowflake it lacks unique constraints. Unlike Snowflake it doesn't support primary keys in the traditional sense; they simply enforce physical sort ordering of records.

The engine supports only the latest version of ClickHouse, v25.8, because it requires `UPDATE` and `DELETE`, which were not available in previous versions. The registry schema enables the feature with the required configuration on each table:

```
SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1
```

One wrinkle that had to be worked around: the `clickhouse client` uses the ClickHouse "Native Protocol" on port 9000 by default, while the ODBC driver relies on the HTTP protocol on port 8123 by default. They physically cannot use the same port, so the port specified in a `db:clickhouse` URL cannot be used for the client. Sqitch works around this issue by supporting a custom URL query parameter, `NativePort`, to specify the port for the client to use. Perhaps someday there will be a DBI driver using [clickhouse-cpp](https://github.com/ClickHouse/clickhouse-cpp) and therefor the native protocol. But in the meantime we have to work around this variation between the two connectors.

This implementation is largely complete, but a few things remain to bring it fully in line with the other engines:

- [x] A tutorial (#904)
- [x] Support for parsing the ClickHouse [config file](https://clickhouse.com/docs/interfaces/cli#configuration_files) (#906)
- [x] Configuration file parsing (#906)
- [x] Password-less support (#906)

This last item is difficult, because the behaviors of the `clickhouse client` and the ODBC driver vary considerably.

*   The CLI supports `--jwt` but the [ODBC driver](https://github.com/ClickHouse/clickhouse-odbc) does not
*    The CLI supports SSH authentication with `--ssh-key-file` and `--ssh-key-passphrase` but the ODBC driver does not
*   With `--secure` and a private key specified in a configuration file, the client supports client cert authentication; but the ODBC driver only supports a `PrivateKeyFile` parameter. Sqitch could probably support the former once it learns to parse the config file, but not the latter unless a the client gains a `--private-key` option

At any rate look for those improvements in future commits.