### PR TITLE
Adjust workflow `push` and `pull_request` triggers

### DIFF
--- a/.github/workflows/cockroach.yml
+++ b/.github/workflows/cockroach.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's Cockroach engine on all supported versions of
-# Postgres. It runs for pushes and pull requests on the `main`, `develop`,
-# `**cockroach**`, and `**engine**` branches.
+# CockroachDB. It runs on pushes to branches matching `develop`,
+# `**cockroach**`, and `**engine**` as well as pull requests.
 name: 🪳 Cockroach
 on:
   push:
-    branches: [main, develop, "**engine**", "**cockroach**" ]
+    branches: [develop, "**engine**", "**cockroach**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**cockroach**" ]
 jobs:
   Cockroach:
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,13 +1,12 @@
 # This workflow creates the services and installs the clients in order to run
-# coverage tests. Each engine must be accessible for a complete coverage report.
-# It runs for pushes and pull requests on the `main`, `develop`, and `**cover**`
-# branches.
+# coverage tests. Each engine must be accessible for a complete coverage
+# report. It runs on pushes to branches matching `develop` and `**cover**` as
+# well as pull requests.
 name: 📈 Coverage
 on:
   push:
-    branches: [main, develop, "**cover**"]
+    branches: [develop, "**cover**"]
   pull_request:
-    branches: [main, develop, "**cover**"]
 jobs:
   Snowflake:
     name: 📈 Coverage

--- a/.github/workflows/exasol.yml
+++ b/.github/workflows/exasol.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's Exasol engine on recent supported versions of
-# Oracle. It runs for pushes and pull requests on the `main`, `develop`,
-# `**exasol**`, and `**engine**` branches.
+# Exasol. It runs on pushes to branches matching `develop`, `**exasol**`, and
+# `**engine**` as well as pull requests.
 name: ☀️ Exasol
 on:
   push:
-    branches: [main, develop, "**engine**", "**exasol**" ]
+    branches: [develop, "**engine**", "**exasol**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**exasol**" ]
 jobs:
   Exasol:
     strategy:

--- a/.github/workflows/firebird.yml
+++ b/.github/workflows/firebird.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's Firebird engine on all supported versions of
-# Postgres. It runs for pushes and pull requests on the `main`, `develop`,
-# `**firebird**`, and `**engine**` branches.
+# Firebird. It runs on pushes to branches matching `develop`, `**firebird**`,
+# and `**engine**` as well as pull requests.
 name: 🔥 Firebird
 on:
   push:
-    branches: [main, develop, "**engine**", "**firebird**" ]
+    branches: [develop, "**engine**", "**firebird**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**firebird**" ]
 jobs:
   Firebird:
     strategy:

--- a/.github/workflows/maria.yml
+++ b/.github/workflows/maria.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's MySQL engine on all supported versions of
-# MariaDB. It runs for pushes and pull requests on the `main`, `develop`,
-# `**mysql**`, `**maria**`, and `**engine**` branches.
+# MariaDB. It runs on pushes to branches matching `develop`, `**mysql**`,
+# `**maria**`, and `**engine**` as well as pull requests.
 name: 🦭 MariaDB
 on:
   push:
-    branches: [main, develop, "**engine**", "**mysql**", "**maria**" ]
+    branches: [develop, "**engine**", "**mysql**", "**maria**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**mysql**", "**maria**" ]
 jobs:
   MySQL:
     strategy:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's MySQL engine on all supported versions of
-# MySQL. It runs for pushes and pull requests on the `main`, `develop`,
-# `**mysql**`, `**maria**`, and `**engine**` branches.
+# MySQL. It runs on pushes to branches matching `develop`, `**mysql**`,
+# `**maria**`, and `**engine**` as well as pull requests.
 name: 🐬 MySQL
 on:
   push:
-    branches: [main, develop, "**engine**", "**mysql**", "**maria**" ]
+    branches: [develop, "**engine**", "**mysql**", "**maria**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**mysql**", "**maria**" ]
 jobs:
   MySQL:
     strategy:

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's Oracle engine on recent supported versions of
-# Oracle. It runs for pushes and pull requests on the `main`, `develop`,
-# `**oracle**`, and `**engine**` branches.
+# Oracle. It runs on pushes to branches matching `develop`, `**oracle**`, and
+# `**engine**` as well as pull requests.
 name: 🔮 Oracle
 on:
   push:
-    branches: [main, develop, "**engine**", "**oracle**" ]
+    branches: [develop, "**engine**", "**oracle**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**oracle**" ]
 jobs:
   Oracle:
     strategy:

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -5,7 +5,6 @@
 name: 💿 OS
 on:
   push:
-    branches: ['*']
   pull_request:
   schedule:
     - cron:  '0 14 2 * *' # Monthly at 2pm on the second

--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -1,12 +1,12 @@
-# This workflow tests Sqitch's basic functionality (no database testing) on all
-# supported versions of Perl on Ubuntu, macOS, and Windows. It runs for pushes
-# and pull requests on the main and develop branches.
+# This workflow tests Sqitch's basic functionality (no database testing) on
+# all supported versions of Perl on Ubuntu, macOS, and Windows. It runs on
+# pushes to branches matching `develop` and `**perl**` as well as pull
+# requests.
 name: 🧅 Perl
 on:
   push:
-    branches: [main, develop, "**perl**"]
+    branches: [develop, "**perl**"]
   pull_request:
-    branches: [main, develop, "**perl**"]
 jobs:
   Perl:
     strategy:

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's PostgreSQL engine on all supported versions of
-# Postgres. It runs for pushes and pull requests on the `main`, `develop`,
-# `**postgres**`, `**yugabyte**`, and `**engine**` branches.
+# Postgres. It runs on pushes to branches matching `develop`, `**postgres**`,
+# `**yugabyte**`, and `**engine**` as well as pull requests.
 name: 🐘 Postgres
 on:
   push:
-    branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
+    branches: [develop, "**engine**", "**postgres**", "**yugabyte**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
 jobs:
   Postgres:
     strategy:

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -1,11 +1,11 @@
-# This workflow tests Sqitch's Snowflake engine. It runs for pushes and pull
-# requests on the `main`, `develop`, `**snowflake**`, and `**engine**` branches.
+# This workflow tests Sqitch's Snowflake engine. It runs on pushes to branches
+# matching `develop`, `**snowflake**`, and `**engine**` as well as pull
+# requests.
 name: ❄️ Snowflake
 on:
   push:
-    branches: [main, develop, "**engine**", "**snowflake**" ]
+    branches: [develop, "**engine**", "**snowflake**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**snowflake**" ]
 jobs:
   Snowflake:
     name: ❄️ Snowflake

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's SQLite engine on all supported versions of
-# Postgres. It runs for pushes and pull requests on the `main`, `develop`,
-# `**sqlite**`, and `**engine**` branches.
+# SQLite. It runs on pushes to branches matching `develop`, `**sqlite**`, and
+# `**engine**` as well as pull requests.
 name: 💡 SQLite
 on:
   push:
-    branches: [main, develop, "**engine**", "**sqlite**" ]
+    branches: [develop, "**engine**", "**sqlite**"]
   pull_request:
-    branches: [main, develop, "**engine**", "**sqlite**" ]
 jobs:
   SQLite:
     strategy:

--- a/.github/workflows/vertica.yml
+++ b/.github/workflows/vertica.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's Vertica engine on all supported versions of
-# Vertica. It runs for pushes and pull requests on the `main`, `develop`,
-# `**vertica**`, and `**engine**` branches.
+# Vertica. It runs on pushes to branches matching `develop`, `**vertica**`,
+# and `**engine**` as well as pull requests.
 name: 🔺 Vertica
 on:
   push:
-    branches: [main, develop, "**engine**", "**vertica**" ]
+    branches: [develop, "**engine**", "**vertica**" ]
   pull_request:
-    branches: [main, develop, "**engine**", "**vertica**" ]
 jobs:
   Vertica:
     strategy:

--- a/.github/workflows/yugabyte.yml
+++ b/.github/workflows/yugabyte.yml
@@ -1,12 +1,11 @@
 # This workflow tests Sqitch's PostgreSQL engine on all supported versions of
-# YugabyteDB. It runs for pushes and pull requests on the `main`, `develop`,
-# `**postgres**`, `**yugabyte**`, and `**engine**` branches.
+# YugabyteDB. It runs on pushes to branches matching `develop`,
+# `**postgres**`, `**yugabyte**`, and `**engine**` as well as pull requests.
 name: 💫 Yugabyte
 on:
   push:
-    branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
+    branches: [develop, "**engine**", "**postgres**", "**yugabyte**" ]
   pull_request:
-    branches: [main, develop, "**engine**", "**postgres**", "**yugabyte**" ]
 jobs:
   Yugabyte:
     strategy:


### PR DESCRIPTION
The `branches` limitation on pull requests effectively did nothing, because they're always submitted against `develop` or `main`, and the trigger is for the branch to be merged into, not from. So remove the `branches` bit from `pull_request`.

Limit running most tests on branches as before, but remove `main`. With the current pull request process, everything should work properly in develop before merging to main, do don't bother with main Do, however, still run them on `develop`, even though most changes will come through pull requests where tests must have passed, to preserve an extra layer of quality protection.