### PR TITLE
Search for `clickhouse` and `clickhouse-client`

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,11 +6,11 @@ Revision history for Perl extension App::Sqitch
        replaces inline uses of `split`. This allows the tests to more
        consistently compare arrays as arrays, though `search_events` must now
        always parse `tags`, `requires`, and `conflicts`.
-     - Added support for ClickHouse. It relies on the C<clickhouse> CLI and
-       ODBC driver. Like MySQL, it uses a database for the registry schema,
-       where the tables use the C<MergeTree> engine, and supports client
-       certificate authentication and the ClickHouse client configuration
-       file format.
+     - Added support for ClickHouse. It relies on the `clickhouse` (or
+       `clickhouse-client`) CLI and ODBC driver. Like MySQL, it uses a
+       database for the registry schema, where the tables use the `MergeTree`
+       engine, and supports client certificate authentication and the
+       ClickHouse client configuration file format.
 
 1.5.2  2025-04-29T15:13:35Z
      - Added missing German translations, thanks to @0xflotus for the PR

--- a/lib/App/Sqitch/Engine/firebird.pm
+++ b/lib/App/Sqitch/Engine/firebird.pm
@@ -931,8 +931,10 @@ sub default_client {
     open STDERR, '>&', $olderr or hurl firebird => __x(
         'Cannot dup STDERR: {error}', $!
     );
-    hurl firebird => __(
-        'Unable to locate Firebird ISQL; set "engine.firebird.client" via sqitch config'
+    hurl firebird => __x(
+        'Unable to locate {cli} client; set "engine.{eng}.client" via sqitch config',
+        cli => 'Firebird ISQL',
+        eng => 'firebird',
     );
 }
 

--- a/t/firebird.t
+++ b/t/firebird.t
@@ -386,8 +386,10 @@ FSPEC: {
     throws_ok { $fb->default_client } 'App::Sqitch::X',
         'Should get error when no client found';
     is $@->ident, 'firebird', 'Client exception ident should be "firebird"';
-    is $@->message, __(
-        'Unable to locate Firebird ISQL; set "engine.firebird.client" via sqitch config'
+    is $@->message, __x(
+        'Unable to locate {cli} client; set "engine.{eng}.client" via sqitch config',
+        cli => 'Firebird ISQL',
+        eng => 'firebird',
     ), 'Client exception message should be correct';
 }
 


### PR DESCRIPTION
Bare `clickhouse` is the canonical name, and `clickhouse-client` should generally be a symlink, but some packages, like the [clickhouse-client Apt package], just have `clickhouse-client`. This is a bad assumption and should not be the default.

So search the path for both and return the first one found. Raise an error if neither is found. Adopt and generalize the error message previously used by the Firebird engine.

In passing, update the error regular expression to match more generally. Previously it matched unixODBC-specific errors, which did not work on macOS using the [clickhouse-odbc Homebrew formula], which uses iODBC. So switch to an error message that comes only from the ClickHouse server.

  [clickhouse-client Apt package]: https://packages.debian.org/bullseye/clickhouse-client
  [clickhouse-odbc Homebrew formula]: https://formulae.brew.sh/formula/clickhouse-odbc#default